### PR TITLE
Use sqlite in-memory db for userdict

### DIFF
--- a/src/ime-core/userdict.h
+++ b/src/ime-core/userdict.h
@@ -47,7 +47,7 @@
 class CUserDict
 {
 public:
-     CUserDict () : m_db(NULL) {}
+     CUserDict () : m_fname(NULL), m_db(NULL) {}
 
     ~CUserDict () {free ();}
 
@@ -64,9 +64,17 @@ public:
     const TWCHAR* operator [] (unsigned wid);
 
 private:
+    enum DBCopyDirection
+    {
+        Load,
+        Save
+    };
+
+    int _copyDb(DBCopyDirection direction);
     bool _createTable();
     bool _createIndexes();
 
+    char                       *m_fname;
     sqlite3                    *m_db;
     std::map<unsigned, wstring> m_dict;
 };


### PR DESCRIPTION
Loads the userdict from disk in to in-memory database when starts up
and saves when exits. This improves the performance dramatically when
the userdict is large.
