### PR TITLE
Fixes Scons permission issue on OS X

### DIFF
--- a/python/quanpin_trie_gen.py
+++ b/python/quanpin_trie_gen.py
@@ -37,6 +37,7 @@
 
 import pinyin_data
 import trie
+import sys
 
 orig_trie = trie.Trie ()
 pytrie = trie.DATrie ()
@@ -45,5 +46,5 @@ for syllable, hex_syllable in pinyin_data.valid_syllables.items():
     orig_trie.add(syllable[::-1], hex_syllable)
 
 pytrie.construct_from_trie (orig_trie)
-pytrie.output_static_c_arrays ("/dev/stdout")
+pytrie.output_static_c_arrays (sys.stdout)
 

--- a/python/trie.py
+++ b/python/trie.py
@@ -187,8 +187,7 @@ class DATrie (object):
 
         f.close()
 
-    def output_static_c_arrays (self, fname):
-        f = open(fname, 'w+')
+    def output_static_c_arrays (self, f):
         l = len (self.base)
 
         c_type = "int" if l > 2**15 else "short"


### PR DESCRIPTION
Code change to fix the following error on OS X：

```
Traceback (most recent call last):
  File "./quanpin_trie_gen.py", line 48, in <module>
    pytrie.output_static_c_arrays ("/dev/stdout")
  File "./trie.py", line 191, in output_static_c_arrays
    f = open(fname, 'w+')
IOError: [Errno 13] Permission denied: '/dev/stdout'
scons: *** [src/pinyin/quanpin_trie.h] Error 1
scons: building terminated because of errors.
```
