### PR TITLE
Add <setup> tag to IBus engine meta-data

### DIFF
--- a/wrapper/ibus/data/sunpinyin.xml.in
+++ b/wrapper/ibus/data/sunpinyin.xml.in
@@ -22,6 +22,7 @@
       <longname>SunPinyin</longname>
       <description>SunPinyin Input Method</description>
       <rank>99</rank>
+      <setup>@LIBEXEC_DIR@/ibus-setup-sunpinyin</setup>
     </engine>
   </engines>
 </component>


### PR DESCRIPTION
This is needed for Debian and Ubuntu.

"ibus-sunpinyin" Debian package installs "ibus-setup-sunpinyin" to /usr/lib/ibus-sunpinyin/ ; "ibus-setup" cannot find the setup program automatically and thus render "Preferences" button gray.
http://packages.ubuntu.com/raring/amd64/ibus-sunpinyin/filelist

Add explicit <setup> can solve this problem.
