### PR TITLE
Handle AArch64 architecture

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -313,7 +313,8 @@ def AppendEndianCheck(conf):
   || defined(_POWER)   || defined(__powerpc__) \
   || defined(__ppc__)  || defined(__hpux) || defined(__hppa) \
   || defined(_MIPSEB)  || defined(_POWER) \
-  || defined(__s390__) || (defined(__sh__) && defined(__BIG_ENDIAN__))
+  || defined(__s390__) || (defined(__sh__) && defined(__BIG_ENDIAN__)) \
+  || defined(__AARCH64EB__)
 # define WORDS_BIGENDIAN 1
 
 #elif defined(__i386__) || defined(__i386) \
@@ -324,7 +325,8 @@ def AppendEndianCheck(conf):
   || defined(__x86_64)  || defined(__x86_64__) \
   || defined(_M_X64)    || defined(__bfin__) \
   || defined(__alpha__) || defined(__ARMEL__) \
-  || defined(_MIPSEL)   || (defined(__sh__) && defined(__LITTLE_ENDIAN__))
+  || defined(_MIPSEL)   || (defined(__sh__) && defined(__LITTLE_ENDIAN__)) \
+  || defined(__AARCH64EL__)
 # undef WORDS_BIGENDIAN
 
 #else


### PR DESCRIPTION
This change allows sunpinyin to be built on AArch64 (64bit ARM) hardware.

Signed-off-by: Marcin Juszkiewicz mjuszkiewicz@redhat.com
