### PR TITLE
pinyin/segmentor.h: fix comparision operator

### DIFF
--- a/src/ime-core/imi_view_classic.cpp
+++ b/src/ime-core/imi_view_classic.cpp
@@ -194,8 +194,11 @@ CIMIClassicView::onKeyEvent(const CKeyEvent& key)
                && !m_pIC->isEmpty()) {
         changeMasks |= KEYEVENT_USED;
         if (m_candiPageFirst > 0) {
-            m_candiPageFirst -= m_candiWindowSize;
-            if (m_candiPageFirst < 0) m_candiPageFirst = 0;
+            if (m_candiPageFirst > m_candiWindowSize) {
+                m_candiPageFirst -= m_candiWindowSize;
+            } else {
+                m_candiPageFirst = 0;
+            }
             changeMasks |= CANDIDATE_MASK;
         }
     } else if (((modifiers == 0 && keycode == IM_VK_PAGE_DOWN)

--- a/src/pinyin/segmentor.h
+++ b/src/pinyin/segmentor.h
@@ -62,7 +62,7 @@ struct IPySegmentor {
                 return true;
 
             if (m_start == other.m_start)
-                return m_len < m_len;
+                return m_len < other.m_len;
 
             return false;
         }

--- a/src/portability.cpp
+++ b/src/portability.cpp
@@ -194,7 +194,7 @@ MBSTOWCS(TWCHAR *pwcs, const char* s, size_t n)
     const unsigned char *src = (const unsigned char*)s;
     TWCHAR* dst = pwcs;
 
-    while (dst - pwcs < n) {
+    while (dst - pwcs < (ssize_t)n) {
         if (*src < 0xc0 || *src >= 0xfe) {
             if (*src < 0x80) *dst++ = *src;
             if (*src++ == 0) break;


### PR DESCRIPTION
this patch also kills a bunch of sign-compare warnings.

let me know if any concerns. i will keep the PR lingering around for couple days before merging it.

thanks,
