### PR TITLE
Fixed SunPinyinLookupTable::cursor_up()

### DIFF
--- a/wrapper/ibus/src/sunpinyin_lookup_table.cpp
+++ b/wrapper/ibus/src/sunpinyin_lookup_table.cpp
@@ -82,7 +82,7 @@ SunPinyinLookupTable::update_candidates(const ICandidateList& cl)
 bool
 SunPinyinLookupTable::cursor_up()
 {
-    ibus_lookup_table_cursor_down(*this);
+    ibus_lookup_table_cursor_up(*this);
     return true;
 }
 


### PR DESCRIPTION
Maybe mistake, use ibus_lookup_table_cursor_up() instead of ibus_lookup_table_cursor_down()