### PR TITLE
Portability fix for NetBSD iconv

### DIFF
--- a/src/portability.h
+++ b/src/portability.h
@@ -72,7 +72,7 @@
 inline double log2(double x) { return log(x) / M_LN2; }
 #endif
 
-#if defined(sun) // Solaris/HP-UX 's iconv is const char**
+#if defined(sun) || defined(__NetBSD__) // Solaris/HP-UX/NetBSD 's iconv is const char**
 typedef const char* TIConvSrcPtr;
 #else
 typedef char* TIConvSrcPtr;


### PR DESCRIPTION
NetBSD's iconv(3) prototype is same as Solaris.