### PR TITLE
slm/thread: fix to use float types properly

### DIFF
--- a/src/slm/thread/slmthread.cpp
+++ b/src/slm/thread/slmthread.cpp
@@ -253,8 +253,8 @@ main(int argc, char* argv[])
 
     bool usingLogPr = slm.isUseLogPr();
 
-    #define EffectivePr(a)  (usingLogPr ? ((a) / log(2.0)) : -log2f((a)))
-    #define OriginalPr(b)   (usingLogPr ? ((b) * log(2.0)) : exp2(-(b)))
+    #define EffectivePr(a)  (usingLogPr ? ((a) / log(2.0f)) : -log2f((a)))
+    #define OriginalPr(b)   (usingLogPr ? ((b) * log(2.0f)) : exp2f(-(b)))
     #define EffectiveBow(a) (usingLogPr ? exp(-(a)) : (a))
     #define OriginalBow(b)  (usingLogPr ? -log((b)) : (b))
 


### PR DESCRIPTION
log() and exp() usages were swited to c++ std::log() and std::exp()
expecting std::log(float) and std::exp(float), then `float` conststants
should be used, and exp2f() should be used to fit log2f() usage.

additionally resolve #62