### PR TITLE
Make the .pc output reproducible

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -429,7 +429,7 @@ env.Substfile('sunpinyin-2.0.pc.in', SUBST_DICT={
     '@VERSION@': version,
     '@CFLAGS@': reduce(lambda a, b: a + ' ' + b,
                        map(lambda x: '-I$${includedir}' + x[3:],
-                           allinc())),
+                           sorted(allinc()))),
 })
 
 libname_default = '%ssunpinyin%s' % (env.subst('${SHLIBPREFIX}'),


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that sunpinyin could not be built reproducibly due to iterating over
the filesystem in a non-deterministic ordering

 [0] https://reproducible-builds.org/

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>