### PR TITLE
fix build

### DIFF
--- a/src/lexicon/pytrie_gen.cpp
+++ b/src/lexicon/pytrie_gen.cpp
@@ -100,7 +100,11 @@ getPureGBEncoding(const char* utf8str)
     static iconv_t ric_gbk = iconv_open("UTF-8", "GBK");
 
     // FIXME
-    if (ic_gb == -1 || ic_gbk == -1 || ric_gb == -1 || ric_gbk == -1) return 3;
+    if (ic_gb   == (iconv_t)-1 ||
+        ic_gbk  == (iconv_t)-1 ||
+        ric_gb  == (iconv_t)-1 ||
+        ric_gbk == (iconv_t)-1)
+            return 3;
     unsigned ret = 0;
 
     if (!isCorrectConverted(utf8str, ic_gb, ric_gb)) {


### PR DESCRIPTION
Previously fails with:

    src/lexicon/pytrie_gen.cpp:103:19: error: ISO C++ forbids comparison
    between pointer and integer