### PR TITLE
SConstruct: Add support for riscv64 architecture

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -333,6 +333,7 @@ def AppendEndianCheck(conf):
   || defined(_M_X64)    || defined(__bfin__) \
   || defined(__alpha__) || defined(__ARMEL__) \
   || defined(_MIPSEL)   || (defined(__sh__) && defined(__LITTLE_ENDIAN__)) \
+  || defined(__riscv) \
   || defined(__AARCH64EL__)
 # undef WORDS_BIGENDIAN
 


### PR DESCRIPTION
This commit adds support for the newly emerged riscv64 architecture.

Original author: "Manuel A. Fernandez Montecelo" <mafm@debian.org>
Downstream report: https://bugs.debian.org/898019