### PR TITLE
slm: Check fopen result

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -322,7 +322,7 @@ def AppendEndianCheck(conf):
   || defined(_MIPSEB)  || defined(_POWER) \
   || defined(__s390__) || (defined(__sh__) && defined(__BIG_ENDIAN__)) \
   || defined(__AARCH64EB__) \
-  || definied(__m68k__)
+  || defined(__m68k__)
 # define WORDS_BIGENDIAN 1
 
 #elif defined(__i386__) || defined(__i386) \

--- a/src/slm/ids2ngram/ids2ngram.cpp
+++ b/src/slm/ids2ngram/ids2ngram.cpp
@@ -178,9 +178,14 @@ main(int argc, char* argv[])
     FILE *swap = fopen(swapfile, "wb+");
     FILE *out = fopen(output, "wb+");
     if (optind >= argc) ShowUsage();
-    while (optind < argc) {
+    for (; optind < argc; ++optind) {
         printf("Processing %s:", argv[optind]); fflush(stdout);
         FILE *fp = fopen(argv[optind], "rb");
+        if (fp == NULL) {
+            fprintf(stderr, "Failed to open %s: %s\n", argv[optind], strerror(errno));
+            printf("\n");
+            continue;
+        }
         switch (N) {
         case 1:
             ProcessingRead<1>(fp, swap, para_offsets, paraMax);
@@ -193,8 +198,7 @@ main(int argc, char* argv[])
             break;
         }
         fclose(fp);
-        printf("\n"); fflush(stdout);
-        ++optind;
+        printf("\n");
     }
     printf("Merging..."); fflush(stdout);
     switch (N) {

--- a/src/slm/mmseg/mmseg.cpp
+++ b/src/slm/mmseg/mmseg.cpp
@@ -307,10 +307,10 @@ main(int argc, char *argv[])
                         ftell(fp),
                         nWords,
                         nAmbis); fflush(stderr);
+                fclose(fp);
             } else {
-                fprintf(stderr, "Can not Open!!!!!!!\n"); fflush(stderr);
+                fprintf(stderr, "Failed to open %s: %s\n", argv[i], strerror(errno));
             }
-            fclose(fp);
         }
     }
 

--- a/src/slm/slmbuild/slmbuild.cpp
+++ b/src/slm/slmbuild/slmbuild.cpp
@@ -239,7 +239,13 @@ main(int argc, char* argv[])
     CSlmBuilder::FREQ_TYPE freq;
 
     printf("Reading and Processing raw idngram..."); fflush(stdout);
-    FILE *fp = fopen(inputfilename, "rb");
+
+    FILE* fp = fopen(inputfilename, "rb");
+    if (fp == NULL) {
+        fprintf(stderr, "Failed to open raw idngram file %s: %s\n", inputfilename, strerror(errno));
+        return EXIT_FAILURE;
+    }
+
     int nItems = 0;
     while (fread(ngram, sizeof(TSIMWordId), N, fp) == (size_t) N
            && fread(&freq, sizeof(freq), 1, fp) == 1) {

--- a/src/slm/slminfo/slminfo.cpp
+++ b/src/slm/slminfo/slminfo.cpp
@@ -261,13 +261,12 @@ PrintSimple(FILE* fp)
 int
 main(int argc, char* argv[])
 {
-    FILE* fp = NULL;
-
     getParameters(argc, argv);
 
-    if ((fp = fopen(argv[argc - 1], "rb+")) == NULL) {
-        printf("Can not open back-off language model file %s\n", argv[argc - 1]);
-        return 99;
+    FILE* fp = fopen(argv[argc - 1], "rb+");
+    if (fp == NULL) {
+        fprintf(stderr, "Failed to open back-off language model file %s: %s\n", argv[argc - 1], strerror(errno));
+        return EXIT_FAILURE;
     }
 
     if (!verbose)

--- a/src/slm/slminfo/slminfo.cpp
+++ b/src/slm/slminfo/slminfo.cpp
@@ -215,6 +215,10 @@ PrintARPA(FILE* fp, const char* lexicon_filename, bool output_log_pr)
     if (lexicon_filename != NULL) {
         plexicon = new TReverseLexicon();
         FILE* f_lex = fopen(lexicon_filename, "r");
+        if (f_lex == NULL) {
+            fprintf(stderr, "Failed to open lexicon file %s: %s\n", lexicon_filename, strerror(errno));
+            exit(EXIT_FAILURE);
+        }
         while (fgets(word, 10240, f_lex) != NULL) {
             if (strlen(word) > 0) {
                 char* p = word;

--- a/src/slm/slmpack/slmpack.cpp
+++ b/src/slm/slmpack/slmpack.cpp
@@ -76,6 +76,10 @@ read_lexicon(const char* filename)
     printf("Loading lexicon..."); fflush(stdout);
     static char word[1024 * 10];
     FILE* f_lex = fopen(filename, "r");
+    if (f_lex == NULL) {
+        fprintf(stderr, "Failed to open lexicon file %s: %s\n", filename, strerror(errno));
+        exit(EXIT_FAILURE);
+    }
     TLexicon lexicon;
     while (fgets(word, sizeof(word), f_lex)) {
         if (strlen(word) > 0) {

--- a/src/slm/slmseg/slmseg.cpp
+++ b/src/slm/slmseg/slmseg.cpp
@@ -469,11 +469,10 @@ main(int argc, char *argv[])
                 fprintf(stderr, "@Offset %ld, %d words, %d ambiguious. Done!\n",
                         ftell(fp), nWords, nAmbis);
                 fflush(stderr);
+                fclose(fp);
             } else {
-                fprintf(stderr, "Can not Open!!!!!!!\n");
-                fflush(stderr);
+                fprintf(stderr, "Failed to open %s: %s\n", argv[i], strerror(errno));
             }
-            fclose(fp);
         }
     }
 

--- a/src/slm/tools/clean_rmrb.cpp
+++ b/src/slm/tools/clean_rmrb.cpp
@@ -79,6 +79,10 @@ main(int argc, char *argv[])
     unsigned char buf[10240];
     for (int i = 1; i < argc; ++i) {
         FILE *fp = fopen(argv[i], "r");
+        if (fp == NULL) {
+            fprintf(stderr, "Failed to open %s: %s\n", argv[i], strerror(errno));
+            continue;
+        }
         while (fgets((char*)buf, sizeof(buf), fp) != NULL) {
             bool emptyline = processline(buf);
             if ((unsigned int)buf[0] == '#' || (unsigned int)buf[0] == '0')

--- a/src/slm/tslminfo/tslminfo.cpp
+++ b/src/slm/tslminfo/tslminfo.cpp
@@ -230,6 +230,10 @@ PrintARPA(CIterateThreadSlm& itslm,
     if (lexicon_filename != NULL) {
         plexicon = new TReverseLexicon();
         FILE* f_lex = fopen(lexicon_filename, "r");
+        if (f_lex == NULL) {
+            fprintf(stderr, "Failed to open lexicon file %s: %s\n", lexicon_filename, strerror(errno));
+            exit(EXIT_FAILURE);
+        }
         while (fgets(word, 10240, f_lex) != NULL) {
             if (strlen(word) > 0) {
                 char* p = word;


### PR DESCRIPTION
Currently some slm tools do not check fopen result. This may cause a
SIGSEGV when the given file does not exist.

Signed-off-by: David Yang <mmyangfl@gmail.com>