### PR TITLE
wrapper: ibus: setup/main.py: Make script compatible with python3 by using ibus gi binding

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -322,7 +322,7 @@ def AppendEndianCheck(conf):
   || defined(_MIPSEB)  || defined(_POWER) \
   || defined(__s390__) || (defined(__sh__) && defined(__BIG_ENDIAN__)) \
   || defined(__AARCH64EB__) \
-  || definied(__m68k__)
+  || defined(__m68k__)
 # define WORDS_BIGENDIAN 1
 
 #elif defined(__i386__) || defined(__i386) \

--- a/wrapper/ibus/setup/main.py
+++ b/wrapper/ibus/setup/main.py
@@ -43,7 +43,12 @@ except ImportError:
     from gi import require_version as gi_require_version
     gi_require_version('Gtk', '3.0')
     from gi.repository import Gtk as gtk
-import ibus
+try:
+    import ibus
+except ImportError:
+    from gi import require_version as gi_require_version
+    gi_require_version('IBus', '1.0')
+    from gi.repository import IBus as ibus
 import gettext
 import locale
 


### PR DESCRIPTION
Downstream bug report: https://bugs.debian.org/769560

With python2 fading away, the future of python3 scripts in ibus-sunpinyin is to use gobject-introspection binding. This simple fix should keep compatibility for both python2/python3.

I haven't test whether this change will make ibus-sunpinyin fully compatible with python3; more testing is welcom.