### PR TITLE
Use CPPFLAGS environment variable

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -259,6 +259,7 @@ libdir = env['LIBDIR']
 # pass through environmental variables
 envvar = [('CC', 'CC'),
           ('CXX', 'CXX'),
+          ('CPPFLAGS', 'CPPFLAGS'),
           ('CFLAGS', 'CFLAGS'),
           ('CXXFLAGS', 'CXXFLAGS'),
           ('LDFLAGS', 'LINKFLAGS'),


### PR DESCRIPTION
It's useful when providing additional build flags like -D_FORTIFY_SOURCE=2.