### PR TITLE
wrapper/ibus: SConstruct: Make script python3-compatible

### DIFF
--- a/wrapper/ibus/SConstruct
+++ b/wrapper/ibus/SConstruct
@@ -36,7 +36,7 @@ opts.Add('DATADIR', default='/usr/local/share')
 def PassVariables(envvar, env):
     for (x, y) in envvar:
         if x in os.environ:
-            print 'Warning: you\'ve set %s in the environmental variable!' % x
+            print('Warning: you\'ve set %s in the environmental variable!' % x)
             env[y] = os.environ[x]
 
 env = Environment(ENV=os.environ,

--- a/wrapper/ibus/SConstruct
+++ b/wrapper/ibus/SConstruct
@@ -141,7 +141,7 @@ def DoInstall():
     libexec_target = env.Install(bin_dir, ['ibus-engine-sunpinyin', 
                                            'setup/ibus-setup-sunpinyin'])
     for exec_bin in libexec_target:
-        env.AddPostAction(exec_bin, Chmod(str(exec_bin), 0755))
+        env.AddPostAction(exec_bin, Chmod(str(exec_bin), 0o755))
         
     setup_target = env.Install(data_dir + '/setup',
                                ['setup/setup.xml',


### PR DESCRIPTION
This is a one-liner fix to make `SConstruct` script in `wrapper/ibus` directory to be python3-compatible.