### PR TITLE
Use /usr/bin/env instead of hardcoded python3 path

### DIFF
--- a/python/imdict.py
+++ b/python/imdict.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 # 

--- a/python/importer/import_fcitx_userdict.py
+++ b/python/importer/import_fcitx_userdict.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os, sys
 import codecs

--- a/python/importer/import_fit_userdict.py
+++ b/python/importer/import_fit_userdict.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sqlite3 as sqlite

--- a/python/importer/import_google_userdict.py
+++ b/python/importer/import_google_userdict.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os, sys
 import codecs

--- a/python/importer/import_qim_userdict.py
+++ b/python/importer/import_qim_userdict.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os, sys
 import codecs

--- a/python/importer/import_qq_userdict.py
+++ b/python/importer/import_qq_userdict.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os, sys
 import codecs

--- a/python/importer/import_sogou_celldict.py
+++ b/python/importer/import_sogou_celldict.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # thanks for the reverse engineering efforts of following projects/peoples:
 # http://code.google.com/p/imewlconverter

--- a/python/importer/import_sogou_userdict.py
+++ b/python/importer/import_sogou_userdict.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os, sys
 import codecs

--- a/python/importer/import_ziguang_userdict.py
+++ b/python/importer/import_ziguang_userdict.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os, sys
 import codecs

--- a/python/importer/importer.py
+++ b/python/importer/importer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import os, sys
 import struct
 import sqlite3 as sqlite

--- a/python/mmseg.py
+++ b/python/mmseg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 # 

--- a/python/pinyin_data.py
+++ b/python/pinyin_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 # 

--- a/python/pinyin_info_gen.py
+++ b/python/pinyin_info_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 # 

--- a/python/quanpin_trie_gen.py
+++ b/python/quanpin_trie_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 # 

--- a/python/test.py
+++ b/python/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
 from pyslm import Slm, SlmState

--- a/python/trie.py
+++ b/python/trie.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 # 

--- a/python/utils.py
+++ b/python/utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.


### PR DESCRIPTION
Use `/usr/bin/env` to automatically choose python3 interpreter.

There are some benefits to use this:
1. it's friendly to Python virtual environment
2. on macOS, there is no pre-installed Python3, and recently, it's not possible to modify the system folder. Thus, it's not possible to find a Python3 executable in /usr/bin. But developers can still install Python3 in `/usr/loca/bin`, etc. So, it's better to use `/usr/bin/env` to let it find the appropriate Python3 executable.