### PR TITLE
Force to use python3 interpreter in system path on macOS

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -418,10 +418,18 @@ if not GetOption('clean') and not GetOption('help'):
 # ==============================compile==============================
 #
 env.Object(slmsource)
-env.Command('src/pinyin/quanpin_trie.h', 'python/quanpin_trie_gen.py',
-            'cd ${SOURCE.dir} && ./quanpin_trie_gen.py > ../src/pinyin/quanpin_trie.h')
-env.Command('src/pinyin/pinyin_info.h', 'python/pinyin_info_gen.py',
-            'cd ${SOURCE.dir} && ./pinyin_info_gen.py > ../src/pinyin/pinyin_info.h')
+if GetOS() == 'Darwin':
+    # on Mac OS X, python3 intepreter is not at /usr/bin/python3,
+    # force to use python3 in system path on Mac OS X
+    env.Command('src/pinyin/quanpin_trie.h', 'python/quanpin_trie_gen.py',
+                'cd ${SOURCE.dir} && python3 ./quanpin_trie_gen.py > ../src/pinyin/quanpin_trie.h')
+    env.Command('src/pinyin/pinyin_info.h', 'python/pinyin_info_gen.py',
+                'cd ${SOURCE.dir} && python3 ./pinyin_info_gen.py > ../src/pinyin/pinyin_info.h')
+else:
+    env.Command('src/pinyin/quanpin_trie.h', 'python/quanpin_trie_gen.py',
+                'cd ${SOURCE.dir} && ./quanpin_trie_gen.py > ../src/pinyin/quanpin_trie.h')
+    env.Command('src/pinyin/pinyin_info.h', 'python/pinyin_info_gen.py',
+                'cd ${SOURCE.dir} && ./pinyin_info_gen.py > ../src/pinyin/pinyin_info.h')
 
 SConscript(['src/SConscript', 'man/SConscript', 'doc/SConscript'], exports='env')
 


### PR DESCRIPTION
On macOS, there is no pre-installed Python3, and recently, it's not possible to modify the system folder. Thus, SCons cannot find a Python3 executable in `/usr/bin`.

Developers can still install Python3 in `/usr/local/bin` or somewhere else. So, we can use python3 from the system path to execute the python scripts.
