### PR TITLE
Update macOS wrapper to build with recent XCode build system

### DIFF
--- a/wrapper/macos/English.lproj/MainMenu.xib
+++ b/wrapper/macos/English.lproj/MainMenu.xib
@@ -1,5090 +1,907 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.10">
-	<data>
-		<int key="IBDocument.SystemTarget">1050</int>
-		<string key="IBDocument.SystemVersion">11B26</string>
-		<string key="IBDocument.InterfaceBuilderVersion">1617</string>
-		<string key="IBDocument.AppKitVersion">1138</string>
-		<string key="IBDocument.HIToolboxVersion">566.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">1617</string>
-		</object>
-		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
-			<bool key="EncodedWithXMLCoder">YES</bool>
-			<string>NSColorWell</string>
-			<string>NSMatrix</string>
-			<string>NSMenu</string>
-			<string>NSSliderCell</string>
-			<string>NSButton</string>
-			<string>NSScroller</string>
-			<string>NSTableHeaderView</string>
-			<string>NSCustomObject</string>
-			<string>NSArrayController</string>
-			<string>NSSlider</string>
-			<string>NSTableView</string>
-			<string>NSComboBox</string>
-			<string>NSComboBoxCell</string>
-			<string>NSTextField</string>
-			<string>NSWindowTemplate</string>
-			<string>NSTextFieldCell</string>
-			<string>NSButtonCell</string>
-			<string>NSTableColumn</string>
-			<string>NSView</string>
-			<string>NSPopUpButtonCell</string>
-			<string>NSScrollView</string>
-			<string>NSTabViewItem</string>
-			<string>NSUserDefaultsController</string>
-			<string>NSPopUpButton</string>
-			<string>NSMenuItem</string>
-			<string>NSTabView</string>
-		</object>
-		<object class="NSArray" key="IBDocument.PluginDependencies">
-			<bool key="EncodedWithXMLCoder">YES</bool>
-			<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-		</object>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<bool key="EncodedWithXMLCoder">YES</bool>
-			<object class="NSArray" key="dict.sortedKeys" id="0">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-			</object>
-			<reference key="dict.values" ref="0"/>
-		</object>
-		<object class="NSMutableArray" key="IBDocument.RootObjects" id="602786588">
-			<bool key="EncodedWithXMLCoder">YES</bool>
-			<object class="NSCustomObject" id="839093953">
-				<object class="NSMutableString" key="NSClassName">
-					<characters key="NS.bytes">NSApplication</characters>
-				</object>
-			</object>
-			<object class="NSCustomObject" id="504355175">
-				<string key="NSClassName">FirstResponder</string>
-			</object>
-			<object class="NSCustomObject" id="517753632">
-				<string key="NSClassName">NSApplication</string>
-			</object>
-			<object class="NSCustomObject" id="57193187">
-				<string key="NSClassName">SunPinyinApplicationDelegate</string>
-			</object>
-			<object class="NSMenu" id="183480630">
-				<string key="NSTitle">Menu</string>
-				<object class="NSMutableArray" key="NSMenuItems">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-					<object class="NSMenuItem" id="1072444278">
-						<reference key="NSMenu" ref="183480630"/>
-						<string key="NSTitle">Chinese Puncts</string>
-						<string key="NSKeyEquiv">.</string>
-						<int key="NSKeyEquivModMask">262144</int>
-						<int key="NSMnemonicLoc">2147483647</int>
-						<int key="NSState">1</int>
-						<object class="NSCustomResource" key="NSOnImage" id="935239157">
-							<string key="NSClassName">NSImage</string>
-							<string key="NSResourceName">NSMenuCheckmark</string>
-						</object>
-						<object class="NSCustomResource" key="NSMixedImage" id="560774375">
-							<string key="NSClassName">NSImage</string>
-							<string key="NSResourceName">NSMenuMixedState</string>
-						</object>
-					</object>
-					<object class="NSMenuItem" id="402399656">
-						<reference key="NSMenu" ref="183480630"/>
-						<string key="NSTitle">Full-Width Symbol</string>
-						<string type="base64-UTF8" key="NSKeyEquiv">IA</string>
-						<int key="NSKeyEquivModMask">524288</int>
-						<int key="NSMnemonicLoc">2147483647</int>
-						<reference key="NSOnImage" ref="935239157"/>
-						<reference key="NSMixedImage" ref="560774375"/>
-						<int key="NSTag">1</int>
-					</object>
-					<object class="NSMenuItem" id="896308868">
-						<reference key="NSMenu" ref="183480630"/>
-						<string key="NSTitle">Preferences...</string>
-						<string key="NSKeyEquiv"/>
-						<int key="NSKeyEquivModMask">1048576</int>
-						<int key="NSMnemonicLoc">2147483647</int>
-						<reference key="NSOnImage" ref="935239157"/>
-						<reference key="NSMixedImage" ref="560774375"/>
-						<int key="NSTag">2</int>
-					</object>
-				</object>
-				<string key="NSName"/>
-			</object>
-			<object class="NSCustomObject" id="61923071">
-				<string key="NSClassName">CandidateWindow</string>
-			</object>
-			<object class="NSWindowTemplate" id="965753792">
-				<int key="NSWindowStyleMask">147</int>
-				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{330, 439}, {432, 419}}</string>
-				<int key="NSWTFlags">1886912512</int>
-				<string key="NSWindowTitle">Preferences</string>
-				<string key="NSWindowClass">NSPanel</string>
-				<object class="NSMutableString" key="NSViewClass">
-					<characters key="NS.bytes">View</characters>
-				</object>
-				<nil key="NSUserInterfaceItemIdentifier"/>
-				<object class="NSView" key="NSWindowView" id="881402259">
-					<reference key="NSNextResponder"/>
-					<int key="NSvFlags">256</int>
-					<object class="NSMutableArray" key="NSSubviews">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSTabView" id="920744728">
-							<reference key="NSNextResponder" ref="881402259"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{13, 10}, {406, 403}}</string>
-							<reference key="NSSuperview" ref="881402259"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="556411416"/>
-							<object class="NSMutableArray" key="NSTabViewItems">
-								<bool key="EncodedWithXMLCoder">YES</bool>
-								<object class="NSTabViewItem" id="844599924">
-									<string key="NSIdentifier">1</string>
-									<object class="NSView" key="NSView" id="556411416">
-										<reference key="NSNextResponder" ref="920744728"/>
-										<int key="NSvFlags">256</int>
-										<object class="NSMutableArray" key="NSSubviews">
-											<bool key="EncodedWithXMLCoder">YES</bool>
-											<object class="NSTextField" id="470745416">
-												<reference key="NSNextResponder" ref="556411416"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{23, 321}, {145, 17}}</string>
-												<reference key="NSSuperview" ref="556411416"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="588621662"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="511728981">
-													<int key="NSCellFlags">68288064</int>
-													<int key="NSCellFlags2">71304192</int>
-													<string key="NSContents">Pinyin Mode:</string>
-													<object class="NSFont" key="NSSupport" id="197917625">
-														<string key="NSName">LucidaGrande</string>
-														<double key="NSSize">13</double>
-														<int key="NSfFlags">1044</int>
-													</object>
-													<reference key="NSControlView" ref="470745416"/>
-													<object class="NSColor" key="NSBackgroundColor" id="126660839">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">controlColor</string>
-														<object class="NSColor" key="NSColor" id="92692141">
-															<int key="NSColorSpace">3</int>
-															<bytes key="NSWhite">MC42NjY2NjY2NjY3AA</bytes>
-														</object>
-													</object>
-													<object class="NSColor" key="NSTextColor" id="441432662">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">controlTextColor</string>
-														<object class="NSColor" key="NSColor" id="343701635">
-															<int key="NSColorSpace">3</int>
-															<bytes key="NSWhite">MAA</bytes>
-														</object>
-													</object>
-												</object>
-											</object>
-											<object class="NSMatrix" id="588621662">
-												<reference key="NSNextResponder" ref="556411416"/>
-												<int key="NSvFlags">256</int>
-												<string key="NSFrame">{{171, 296}, {163, 42}}</string>
-												<reference key="NSSuperview" ref="556411416"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="752296786"/>
-												<bool key="NSEnabled">YES</bool>
-												<int key="NSNumRows">2</int>
-												<int key="NSNumCols">1</int>
-												<object class="NSMutableArray" key="NSCells">
-													<bool key="EncodedWithXMLCoder">YES</bool>
-													<object class="NSButtonCell" id="764653811">
-														<int key="NSCellFlags">-2080244224</int>
-														<int key="NSCellFlags2">0</int>
-														<string key="NSContents">Quan Pin</string>
-														<reference key="NSSupport" ref="197917625"/>
-														<reference key="NSControlView" ref="588621662"/>
-														<int key="NSButtonFlags">1211912703</int>
-														<int key="NSButtonFlags2">0</int>
-														<object class="NSButtonImageSource" key="NSAlternateImage" id="754820507">
-															<string key="NSImageName">NSRadioButton</string>
-														</object>
-														<string key="NSAlternateContents"/>
-														<object class="NSMutableString" key="NSKeyEquivalent" id="286337086">
-															<characters key="NS.bytes"/>
-														</object>
-														<int key="NSPeriodicDelay">200</int>
-														<int key="NSPeriodicInterval">25</int>
-													</object>
-													<object class="NSButtonCell" id="971686497">
-														<int key="NSCellFlags">67239424</int>
-														<int key="NSCellFlags2">0</int>
-														<string key="NSContents">Shuang Pin</string>
-														<reference key="NSSupport" ref="197917625"/>
-														<reference key="NSControlView" ref="588621662"/>
-														<int key="NSTag">1</int>
-														<int key="NSButtonFlags">1211912703</int>
-														<int key="NSButtonFlags2">0</int>
-														<reference key="NSAlternateImage" ref="754820507"/>
-														<string key="NSAlternateContents"/>
-														<reference key="NSKeyEquivalent" ref="286337086"/>
-														<int key="NSPeriodicDelay">200</int>
-														<int key="NSPeriodicInterval">25</int>
-													</object>
-												</object>
-												<string key="NSCellSize">{163, 20}</string>
-												<string key="NSIntercellSpacing">{4, 2}</string>
-												<int key="NSMatrixFlags">1143480320</int>
-												<string key="NSCellClass">NSActionCell</string>
-												<object class="NSButtonCell" key="NSProtoCell" id="557873841">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">Radio</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">0</int>
-													<object class="NSImage" key="NSNormalImage">
-														<int key="NSImageFlags">549453824</int>
-														<string key="NSSize">{18, 18}</string>
-														<object class="NSMutableArray" key="NSReps">
-															<bool key="EncodedWithXMLCoder">YES</bool>
-															<object class="NSArray">
-																<bool key="EncodedWithXMLCoder">YES</bool>
-																<integer value="0"/>
-																<object class="NSBitmapImageRep">
-																	<object class="NSData" key="NSTIFFRepresentation">
-																		<bytes key="NS.bytes">TU0AKgAABRgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAMAAAADAAAAAwAAAAAAAAAA
-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAADwRERGLJycnySsrK/A1NTXw
-IyMjyRwcHIsJCQk8AAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFFRUVdVBQUOCoqKj/
-29vb//n5+f/6+vr/2tra/6qqqv9UVFTgHx8fdQAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUZGRl5
-dXV198PDw//8/Pz////////////////////////////U1NT/fHx89yUlJXkAAAAFAAAAAAAAAAAAAAAA
-AAAAAxEREUZqamrmtbW1/+3t7f/+/v7//v7+//7+/v/9/f3//f39//39/f/39/f/xMTE/3d3d+YZGRlG
-AAAAAwAAAAAAAAAAAAAACkJCQqGtra3/xsbG/+vr6//y8vL/9fX1//X19f/z8/P/9fX1//Ly8v/u7u7/
-0tLS/6+vr/9KSkqhAAAACgAAAAAAAAAAAAAAF3h4eN2/v7//z8/P/93d3f/q6ur/7+/v/+/v7//w8PD/
-7e3t/+3t7f/i4uL/zs7O/8XFxf98fHzdAAAAFwAAAAAAAAADAAAAJKSkpPjOzs7/2dnZ/+Dg4P/i4uL/
-5eXl/+bm5v/n5+f/5eXl/+Li4v/e3t7/2tra/9DQ0P+srKz4AAAAJAAAAAMAAAADAAAALrCwsPrW1tb/
-3t7e/+Tk5P/p6en/6+vr/+zs7P/p6en/6+vr/+fn5//k5OT/4ODg/9nZ2f+zs7P6AAAALgAAAAMAAAAD
-AAAALp2dnezg4OD/5eXl/+rq6v/u7u7/8PDw//Dw8P/x8fH/8PDw/+7u7v/q6ur/5ubm/+Hh4f+ZmZns
-AAAALgAAAAMAAAADAAAAJG5ubs/l5eX/6enp/+/v7//y8vL/9vb2//r6+v/5+fn/9/f3//b29v/x8fH/
-6+vr/+Tk5P9ra2vPAAAAJAAAAAMAAAAAAAAAFy4uLpPCwsL67Ozs//Pz8//5+fn//v7+//7+/v/+/v7/
-/v7+//v7+//19fX/8PDw/8LCwvosLCyTAAAAFwAAAAAAAAAAAAAACgAAAENfX1/S5OTk/vn5+f/+/v7/
-///////////////////////////8/Pz/5ubm/l9fX9IAAABDAAAACgAAAAAAAAAAAAAAAwAAABcAAABl
-YmJi3NLS0v3////////////////////////////////V1dX9ZGRk3AAAAGUAAAAXAAAAAwAAAAAAAAAA
-AAAAAAAAAAUAAAAfAAAAZTMzM8KAgIDwv7+//O3t7f/t7e3/v7+//ICAgPAzMzPCAAAAZQAAAB8AAAAF
-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAFwAAAEMAAAB3AAAAnwAAALMAAACzAAAAnwAAAHcAAABD
-AAAAFwAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAoAAAAXAAAAJAAAAC4AAAAu
-AAAAJAAAABcAAAAKAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-AAAAAwAAAAMAAAADAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADQEAAAMAAAABABIAAAEB
-AAMAAAABABIAAAECAAMAAAAEAAAFugEDAAMAAAABAAEAAAEGAAMAAAABAAIAAAERAAQAAAABAAAACAES
-AAMAAAABAAEAAAEVAAMAAAABAAQAAAEWAAMAAAABABIAAAEXAAQAAAABAAAFEAEcAAMAAAABAAEAAAFS
-AAMAAAABAAEAAAFTAAMAAAAEAAAFwgAAAAAACAAIAAgACAABAAEAAQABA</bytes>
-																	</object>
-																</object>
-															</object>
-														</object>
-														<object class="NSColor" key="NSColor">
-															<int key="NSColorSpace">3</int>
-															<bytes key="NSWhite">MCAwAA</bytes>
-														</object>
-													</object>
-													<reference key="NSAlternateImage" ref="754820507"/>
-													<int key="NSPeriodicDelay">400</int>
-													<int key="NSPeriodicInterval">75</int>
-												</object>
-												<reference key="NSSelectedCell" ref="764653811"/>
-												<reference key="NSBackgroundColor" ref="126660839"/>
-												<object class="NSColor" key="NSCellBackgroundColor" id="839116681">
-													<int key="NSColorSpace">3</int>
-													<bytes key="NSWhite">MQA</bytes>
-												</object>
-												<reference key="NSFont" ref="197917625"/>
-											</object>
-											<object class="NSTextField" id="702733738">
-												<reference key="NSNextResponder" ref="556411416"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{35, 163}, {133, 17}}</string>
-												<reference key="NSSuperview" ref="556411416"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="990578515"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="79651666">
-													<int key="NSCellFlags">68288064</int>
-													<int key="NSCellFlags2">71304192</int>
-													<string key="NSContents">Pagings:</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="702733738"/>
-													<reference key="NSBackgroundColor" ref="126660839"/>
-													<reference key="NSTextColor" ref="441432662"/>
-												</object>
-											</object>
-											<object class="NSTextField" id="293563301">
-												<reference key="NSNextResponder" ref="556411416"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{36, 76}, {133, 17}}</string>
-												<reference key="NSSuperview" ref="556411416"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="835054647"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="405082331">
-													<int key="NSCellFlags">68288064</int>
-													<int key="NSCellFlags2">71304192</int>
-													<string key="NSContents">Miscs:</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="293563301"/>
-													<reference key="NSBackgroundColor" ref="126660839"/>
-													<reference key="NSTextColor" ref="441432662"/>
-												</object>
-											</object>
-											<object class="NSButton" id="990578515">
-												<reference key="NSNextResponder" ref="556411416"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{172, 162}, {187, 18}}</string>
-												<reference key="NSSuperview" ref="556411416"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="629023827"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="121487339">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">Use -/= to page up/down</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="990578515"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<object class="NSCustomResource" key="NSNormalImage" id="999525749">
-														<string key="NSClassName">NSImage</string>
-														<string key="NSResourceName">NSSwitch</string>
-													</object>
-													<object class="NSButtonImageSource" key="NSAlternateImage" id="376999508">
-														<string key="NSImageName">NSSwitch</string>
-													</object>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="629023827">
-												<reference key="NSNextResponder" ref="556411416"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{172, 142}, {187, 18}}</string>
-												<reference key="NSSuperview" ref="556411416"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="875297347"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="813143560">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">Use [/] to page up/down</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="629023827"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="875297347">
-												<reference key="NSNextResponder" ref="556411416"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{172, 122}, {187, 18}}</string>
-												<reference key="NSSuperview" ref="556411416"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="668554983"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="319933815">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">Use ,/. to page up/down</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="875297347"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="668554983">
-												<reference key="NSNextResponder" ref="556411416"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{172, 102}, {187, 18}}</string>
-												<reference key="NSSuperview" ref="556411416"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="293563301"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="453322497">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">Use ↑/↓ to page up/down</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="668554983"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSTextField" id="716757700">
-												<reference key="NSNextResponder" ref="556411416"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{14, 258}, {155, 17}}</string>
-												<reference key="NSSuperview" ref="556411416"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="520162109"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="121491139">
-													<int key="NSCellFlags">68288064</int>
-													<int key="NSCellFlags2">71304192</int>
-													<string key="NSContents">Switch English/Chinese:</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="716757700"/>
-													<reference key="NSBackgroundColor" ref="126660839"/>
-													<reference key="NSTextColor" ref="441432662"/>
-												</object>
-											</object>
-											<object class="NSTextField" id="61970638">
-												<reference key="NSNextResponder" ref="556411416"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{-28, 230}, {197, 17}}</string>
-												<reference key="NSSuperview" ref="556411416"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="236533845"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="411558436">
-													<int key="NSCellFlags">68288064</int>
-													<int key="NSCellFlags2">71304192</int>
-													<string key="NSContents">On Switching:</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="61970638"/>
-													<reference key="NSBackgroundColor" ref="126660839"/>
-													<reference key="NSTextColor" ref="441432662"/>
-												</object>
-											</object>
-											<object class="NSButton" id="168635732">
-												<reference key="NSNextResponder" ref="556411416"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{172, 188}, {187, 26}}</string>
-												<reference key="NSSuperview" ref="556411416"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="702733738"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="110272516">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">Force to use US layout</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="168635732"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="835054647">
-												<reference key="NSNextResponder" ref="556411416"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{172, 71}, {236, 26}}</string>
-												<reference key="NSSuperview" ref="556411416"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="920744728"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="539388088">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">Use ⌫ to cancel selections</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="835054647"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSTextField" id="201282708">
-												<reference key="NSNextResponder" ref="556411416"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{55, 193}, {114, 17}}</string>
-												<reference key="NSSuperview" ref="556411416"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="168635732"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="603160133">
-													<int key="NSCellFlags">68288064</int>
-													<int key="NSCellFlags2">71304192</int>
-													<string key="NSContents">Keyboard Layout:</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="201282708"/>
-													<reference key="NSBackgroundColor" ref="126660839"/>
-													<reference key="NSTextColor" ref="441432662"/>
-												</object>
-											</object>
-											<object class="NSPopUpButton" id="520162109">
-												<reference key="NSNextResponder" ref="556411416"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{171, 252}, {189, 26}}</string>
-												<reference key="NSSuperview" ref="556411416"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="61970638"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSPopUpButtonCell" key="NSCell" id="696757669">
-													<int key="NSCellFlags">-2076049856</int>
-													<int key="NSCellFlags2">2048</int>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="520162109"/>
-													<int key="NSButtonFlags">109199615</int>
-													<int key="NSButtonFlags2">129</int>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">400</int>
-													<int key="NSPeriodicInterval">75</int>
-													<object class="NSMenuItem" key="NSMenuItem" id="723833028">
-														<reference key="NSMenu" ref="461553438"/>
-														<string key="NSTitle">None</string>
-														<string key="NSKeyEquiv"/>
-														<int key="NSKeyEquivModMask">1048576</int>
-														<int key="NSMnemonicLoc">2147483647</int>
-														<int key="NSState">1</int>
-														<reference key="NSOnImage" ref="935239157"/>
-														<reference key="NSMixedImage" ref="560774375"/>
-														<string key="NSAction">_popUpItemAction:</string>
-														<reference key="NSTarget" ref="696757669"/>
-													</object>
-													<bool key="NSMenuItemRespectAlignment">YES</bool>
-													<object class="NSMenu" key="NSMenu" id="461553438">
-														<string key="NSTitle">OtherViews</string>
-														<object class="NSMutableArray" key="NSMenuItems">
-															<bool key="EncodedWithXMLCoder">YES</bool>
-															<reference ref="723833028"/>
-															<object class="NSMenuItem" id="854160556">
-																<reference key="NSMenu" ref="461553438"/>
-																<string key="NSTitle">With Caps Lock (⇪)</string>
-																<string key="NSKeyEquiv"/>
-																<int key="NSKeyEquivModMask">1048576</int>
-																<int key="NSMnemonicLoc">2147483647</int>
-																<reference key="NSOnImage" ref="935239157"/>
-																<reference key="NSMixedImage" ref="560774375"/>
-																<string key="NSAction">_popUpItemAction:</string>
-																<reference key="NSTarget" ref="696757669"/>
-															</object>
-															<object class="NSMenuItem" id="911154180">
-																<reference key="NSMenu" ref="461553438"/>
-																<string key="NSTitle">With Shift (⇧)</string>
-																<string key="NSKeyEquiv"/>
-																<int key="NSKeyEquivModMask">1048576</int>
-																<int key="NSMnemonicLoc">2147483647</int>
-																<reference key="NSOnImage" ref="935239157"/>
-																<reference key="NSMixedImage" ref="560774375"/>
-																<string key="NSAction">_popUpItemAction:</string>
-																<reference key="NSTarget" ref="696757669"/>
-															</object>
-														</object>
-													</object>
-													<int key="NSPreferredEdge">1</int>
-													<bool key="NSUsesItemFromMenu">YES</bool>
-													<bool key="NSAltersState">YES</bool>
-													<int key="NSArrowPosition">2</int>
-												</object>
-											</object>
-											<object class="NSPopUpButton" id="236533845">
-												<reference key="NSNextResponder" ref="556411416"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{171, 224}, {189, 26}}</string>
-												<reference key="NSSuperview" ref="556411416"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="201282708"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSPopUpButtonCell" key="NSCell" id="1036969072">
-													<int key="NSCellFlags">-2076049856</int>
-													<int key="NSCellFlags2">2048</int>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="236533845"/>
-													<int key="NSButtonFlags">109199615</int>
-													<int key="NSButtonFlags2">129</int>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">400</int>
-													<int key="NSPeriodicInterval">75</int>
-													<object class="NSMenuItem" key="NSMenuItem" id="25022990">
-														<reference key="NSMenu" ref="911772948"/>
-														<string key="NSTitle">Commit Pinyin String</string>
-														<string key="NSKeyEquiv"/>
-														<int key="NSKeyEquivModMask">1048576</int>
-														<int key="NSMnemonicLoc">2147483647</int>
-														<int key="NSState">1</int>
-														<reference key="NSOnImage" ref="935239157"/>
-														<reference key="NSMixedImage" ref="560774375"/>
-														<string key="NSAction">_popUpItemAction:</string>
-														<reference key="NSTarget" ref="1036969072"/>
-													</object>
-													<bool key="NSMenuItemRespectAlignment">YES</bool>
-													<object class="NSMenu" key="NSMenu" id="911772948">
-														<string key="NSTitle">OtherViews</string>
-														<object class="NSMutableArray" key="NSMenuItems">
-															<bool key="EncodedWithXMLCoder">YES</bool>
-															<reference ref="25022990"/>
-															<object class="NSMenuItem" id="239601200">
-																<reference key="NSMenu" ref="911772948"/>
-																<string key="NSTitle">Commit Chinese Words</string>
-																<string key="NSKeyEquiv"/>
-																<int key="NSKeyEquivModMask">1048576</int>
-																<int key="NSMnemonicLoc">2147483647</int>
-																<reference key="NSOnImage" ref="935239157"/>
-																<reference key="NSMixedImage" ref="560774375"/>
-																<string key="NSAction">_popUpItemAction:</string>
-																<reference key="NSTarget" ref="1036969072"/>
-															</object>
-														</object>
-													</object>
-													<int key="NSPreferredEdge">1</int>
-													<bool key="NSUsesItemFromMenu">YES</bool>
-													<bool key="NSAltersState">YES</bool>
-													<int key="NSArrowPosition">2</int>
-												</object>
-											</object>
-											<object class="NSPopUpButton" id="752296786">
-												<reference key="NSNextResponder" ref="556411416"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{260, 292}, {100, 26}}</string>
-												<reference key="NSSuperview" ref="556411416"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="716757700"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSPopUpButtonCell" key="NSCell" id="260441203">
-													<int key="NSCellFlags">-2076049856</int>
-													<int key="NSCellFlags2">2048</int>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="752296786"/>
-													<int key="NSButtonFlags">109199615</int>
-													<int key="NSButtonFlags2">129</int>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">400</int>
-													<int key="NSPeriodicInterval">75</int>
-													<object class="NSMenuItem" key="NSMenuItem" id="139505003">
-														<reference key="NSMenu" ref="809213331"/>
-														<string key="NSTitle">MS2003</string>
-														<string key="NSKeyEquiv"/>
-														<int key="NSKeyEquivModMask">1048576</int>
-														<int key="NSMnemonicLoc">2147483647</int>
-														<int key="NSState">1</int>
-														<reference key="NSOnImage" ref="935239157"/>
-														<reference key="NSMixedImage" ref="560774375"/>
-														<string key="NSAction">_popUpItemAction:</string>
-														<reference key="NSTarget" ref="260441203"/>
-													</object>
-													<bool key="NSMenuItemRespectAlignment">YES</bool>
-													<object class="NSMenu" key="NSMenu" id="809213331">
-														<string key="NSTitle">OtherViews</string>
-														<object class="NSMutableArray" key="NSMenuItems">
-															<bool key="EncodedWithXMLCoder">YES</bool>
-															<reference ref="139505003"/>
-															<object class="NSMenuItem" id="297660508">
-																<reference key="NSMenu" ref="809213331"/>
-																<string key="NSTitle">ABC</string>
-																<string key="NSKeyEquiv"/>
-																<int key="NSKeyEquivModMask">1048576</int>
-																<int key="NSMnemonicLoc">2147483647</int>
-																<reference key="NSOnImage" ref="935239157"/>
-																<reference key="NSMixedImage" ref="560774375"/>
-																<string key="NSAction">_popUpItemAction:</string>
-																<reference key="NSTarget" ref="260441203"/>
-															</object>
-															<object class="NSMenuItem" id="83198116">
-																<reference key="NSMenu" ref="809213331"/>
-																<string key="NSTitle">ZiRanMa</string>
-																<string key="NSKeyEquiv"/>
-																<int key="NSKeyEquivModMask">1048576</int>
-																<int key="NSMnemonicLoc">2147483647</int>
-																<reference key="NSOnImage" ref="935239157"/>
-																<reference key="NSMixedImage" ref="560774375"/>
-																<string key="NSAction">_popUpItemAction:</string>
-																<reference key="NSTarget" ref="260441203"/>
-															</object>
-															<object class="NSMenuItem" id="596086471">
-																<reference key="NSMenu" ref="809213331"/>
-																<string key="NSTitle">Pinyin++</string>
-																<string key="NSKeyEquiv"/>
-																<int key="NSKeyEquivModMask">1048576</int>
-																<int key="NSMnemonicLoc">2147483647</int>
-																<reference key="NSOnImage" ref="935239157"/>
-																<reference key="NSMixedImage" ref="560774375"/>
-																<string key="NSAction">_popUpItemAction:</string>
-																<reference key="NSTarget" ref="260441203"/>
-															</object>
-															<object class="NSMenuItem" id="654793636">
-																<reference key="NSMenu" ref="809213331"/>
-																<string key="NSTitle">ZiGuang</string>
-																<string key="NSKeyEquiv"/>
-																<int key="NSKeyEquivModMask">1048576</int>
-																<int key="NSMnemonicLoc">2147483647</int>
-																<reference key="NSOnImage" ref="935239157"/>
-																<reference key="NSMixedImage" ref="560774375"/>
-																<string key="NSAction">_popUpItemAction:</string>
-																<reference key="NSTarget" ref="260441203"/>
-															</object>
-															<object class="NSMenuItem" id="219246953">
-																<reference key="NSMenu" ref="809213331"/>
-																<string key="NSTitle">XiaoHe</string>
-																<string key="NSKeyEquiv"/>
-																<int key="NSMnemonicLoc">2147483647</int>
-																<reference key="NSOnImage" ref="935239157"/>
-																<reference key="NSMixedImage" ref="560774375"/>
-																<string key="NSAction">_popUpItemAction:</string>
-																<reference key="NSTarget" ref="260441203"/>
-															</object>
-														</object>
-														<reference key="NSMenuFont" ref="197917625"/>
-													</object>
-													<int key="NSPreferredEdge">1</int>
-													<bool key="NSUsesItemFromMenu">YES</bool>
-													<bool key="NSAltersState">YES</bool>
-													<int key="NSArrowPosition">2</int>
-												</object>
-											</object>
-										</object>
-										<string key="NSFrame">{{10, 33}, {386, 357}}</string>
-										<reference key="NSSuperview" ref="920744728"/>
-										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="470745416"/>
-									</object>
-									<string key="NSLabel">General</string>
-									<reference key="NSColor" ref="126660839"/>
-									<reference key="NSTabView" ref="920744728"/>
-								</object>
-								<object class="NSTabViewItem" id="79480864">
-									<string key="NSIdentifier">Item 2</string>
-									<object class="NSView" key="NSView" id="734104716">
-										<nil key="NSNextResponder"/>
-										<int key="NSvFlags">256</int>
-										<object class="NSMutableArray" key="NSSubviews">
-											<bool key="EncodedWithXMLCoder">YES</bool>
-											<object class="NSButton" id="162798478">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{35, 226}, {63, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="319545690">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">z - zh</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="162798478"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="329315625">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{35, 206}, {63, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="813582582">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">c - ch</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="329315625"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="48727413">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{35, 186}, {63, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="966132901">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">s - sh</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="48727413"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="370432243">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{35, 166}, {77, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="648858317">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">an - ang</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="370432243"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="229798880">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{35, 146}, {78, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="862308995">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">on - ong</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="229798880"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="56171983">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{35, 126}, {78, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="262821321">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">en - eng</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="56171983"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="866594184">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{35, 106}, {78, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="878656198">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">in - ing</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="866594184"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="990409762">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{35, 54}, {88, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="380966888">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">gn -&gt; ng</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="990409762"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="1008888016">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{182, 54}, {88, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="517511508">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">uen -&gt; un</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="1008888016"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="1008852985">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{182, 34}, {88, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="123364609">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">iou -&gt; iu</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="1008852985"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="479912596">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{35, 34}, {92, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="630653599">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">img -&gt; ing</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="479912596"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="896193182">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{35, 14}, {92, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="587691603">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">uei -&gt; ui</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="896193182"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="434024678">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{182, 226}, {86, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="918479979">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">eng - ong</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="434024678"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="932528735">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{182, 206}, {86, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="55673680">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">ian - iang</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="932528735"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="778635181">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{182, 186}, {93, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="795322137">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">uan - uang</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="778635181"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="205848077">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{182, 166}, {93, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="853626170">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">l - n</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="205848077"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="527416780">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{182, 146}, {93, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="1064523668">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">f - h</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="527416780"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="136547617">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{182, 126}, {93, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="201490911">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">r - l</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="136547617"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="566454833">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{182, 106}, {93, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="676075530">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">k - g</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="566454833"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="783710730">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{15, 252}, {101, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="424806521">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">Fuzzy Pinyin</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="783710730"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="778114246">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{15, 329}, {348, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="903629445">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">Smarter Segmentation (only applicable for QuanPin)</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="778114246"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="213192280">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{35, 306}, {348, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="217309235">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">Enable Inner Fuzzies</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="213192280"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="256580922">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{15, 280}, {348, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="876130661">
-													<int key="NSCellFlags">-2080244224</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">Simpler Initials (z/c/s -&gt; zh/ch/sh)</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="256580922"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="639430431">
-												<reference key="NSNextResponder" ref="734104716"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{15, 77}, {289, 18}}</string>
-												<reference key="NSSuperview" ref="734104716"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="60275823">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">Auto Correct (only applicable for QuanPin)</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="639430431"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-										</object>
-										<string key="NSFrame">{{10, 33}, {386, 357}}</string>
-									</object>
-									<string key="NSLabel">Pinyin</string>
-									<reference key="NSColor" ref="126660839"/>
-									<reference key="NSTabView" ref="920744728"/>
-								</object>
-								<object class="NSTabViewItem" id="235566413">
-									<string key="NSIdentifier">2</string>
-									<object class="NSView" key="NSView" id="343563030">
-										<nil key="NSNextResponder"/>
-										<int key="NSvFlags">256</int>
-										<object class="NSMutableArray" key="NSSubviews">
-											<bool key="EncodedWithXMLCoder">YES</bool>
-											<object class="NSTextField" id="387956930">
-												<reference key="NSNextResponder" ref="343563030"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{110, 253}, {38, 17}}</string>
-												<reference key="NSSuperview" ref="343563030"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="353713095">
-													<int key="NSCellFlags">68288064</int>
-													<int key="NSCellFlags2">71304192</int>
-													<string key="NSContents">Font:</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="387956930"/>
-													<reference key="NSBackgroundColor" ref="126660839"/>
-													<reference key="NSTextColor" ref="441432662"/>
-												</object>
-											</object>
-											<object class="NSButton" id="396267292">
-												<reference key="NSNextResponder" ref="343563030"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{284, 240}, {94, 32}}</string>
-												<reference key="NSSuperview" ref="343563030"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="903783181">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">134217728</int>
-													<string key="NSContents">Select ...</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="396267292"/>
-													<int key="NSButtonFlags">-2038284033</int>
-													<int key="NSButtonFlags2">129</int>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSColorWell" id="259224558">
-												<reference key="NSNextResponder" ref="343563030"/>
-												<int key="NSvFlags">268</int>
-												<object class="NSMutableSet" key="NSDragTypes">
-													<bool key="EncodedWithXMLCoder">YES</bool>
-													<object class="NSArray" key="set.sortedObjects">
-														<bool key="EncodedWithXMLCoder">YES</bool>
-														<string>NSColor pasteboard type</string>
-													</object>
-												</object>
-												<string key="NSFrame">{{161, 212}, {92, 23}}</string>
-												<reference key="NSSuperview" ref="343563030"/>
-												<bool key="NSEnabled">YES</bool>
-												<bool key="NSIsBordered">YES</bool>
-												<object class="NSColor" key="NSColor" id="149652997">
-													<int key="NSColorSpace">1</int>
-													<bytes key="NSRGB">MSAwLjUgMAA</bytes>
-												</object>
-											</object>
-											<object class="NSTextField" id="706521650">
-												<reference key="NSNextResponder" ref="343563030"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{14, 215}, {134, 17}}</string>
-												<reference key="NSSuperview" ref="343563030"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="419039838">
-													<int key="NSCellFlags">68288064</int>
-													<int key="NSCellFlags2">71304192</int>
-													<string key="NSContents">Background:</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="706521650"/>
-													<reference key="NSBackgroundColor" ref="126660839"/>
-													<reference key="NSTextColor" ref="441432662"/>
-												</object>
-											</object>
-											<object class="NSTextField" id="344543120">
-												<reference key="NSNextResponder" ref="343563030"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{14, 177}, {134, 17}}</string>
-												<reference key="NSSuperview" ref="343563030"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="79979143">
-													<int key="NSCellFlags">68288064</int>
-													<int key="NSCellFlags2">71304192</int>
-													<string key="NSContents">Highlighting:</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="344543120"/>
-													<reference key="NSBackgroundColor" ref="126660839"/>
-													<reference key="NSTextColor" ref="441432662"/>
-												</object>
-											</object>
-											<object class="NSTextField" id="658605159">
-												<reference key="NSNextResponder" ref="343563030"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{54, 142}, {94, 17}}</string>
-												<reference key="NSSuperview" ref="343563030"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="811252156">
-													<int key="NSCellFlags">68288064</int>
-													<int key="NSCellFlags2">71304192</int>
-													<string key="NSContents">Transparency:</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="658605159"/>
-													<reference key="NSBackgroundColor" ref="126660839"/>
-													<reference key="NSTextColor" ref="441432662"/>
-												</object>
-											</object>
-											<object class="NSTextField" id="840782193">
-												<reference key="NSNextResponder" ref="343563030"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{54, 111}, {94, 17}}</string>
-												<reference key="NSSuperview" ref="343563030"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="680292339">
-													<int key="NSCellFlags">68288064</int>
-													<int key="NSCellFlags2">71304192</int>
-													<string key="NSContents">Radius:</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="840782193"/>
-													<reference key="NSBackgroundColor" ref="126660839"/>
-													<reference key="NSTextColor" ref="441432662"/>
-												</object>
-											</object>
-											<object class="NSSlider" id="293499524">
-												<reference key="NSNextResponder" ref="343563030"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{159, 139}, {96, 21}}</string>
-												<reference key="NSSuperview" ref="343563030"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSSliderCell" key="NSCell" id="116399245">
-													<int key="NSCellFlags">-2080244224</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents"/>
-													<object class="NSFont" key="NSSupport" id="898404890">
-														<string key="NSName">Helvetica</string>
-														<double key="NSSize">12</double>
-														<int key="NSfFlags">16</int>
-													</object>
-													<reference key="NSControlView" ref="293499524"/>
-													<double key="NSMaxValue">100</double>
-													<double key="NSMinValue">0.0</double>
-													<double key="NSValue">75</double>
-													<double key="NSAltIncValue">0.0</double>
-													<int key="NSNumberOfTickMarks">0</int>
-													<int key="NSTickMarkPosition">1</int>
-													<bool key="NSAllowsTickMarkValuesOnly">NO</bool>
-													<bool key="NSVertical">NO</bool>
-												</object>
-											</object>
-											<object class="NSSlider" id="921987807">
-												<reference key="NSNextResponder" ref="343563030"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{159, 108}, {96, 21}}</string>
-												<reference key="NSSuperview" ref="343563030"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSSliderCell" key="NSCell" id="565681738">
-													<int key="NSCellFlags">-2080244224</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents"/>
-													<reference key="NSSupport" ref="898404890"/>
-													<reference key="NSControlView" ref="921987807"/>
-													<double key="NSMaxValue">10</double>
-													<double key="NSMinValue">0.0</double>
-													<double key="NSValue">5</double>
-													<double key="NSAltIncValue">0.0</double>
-													<int key="NSNumberOfTickMarks">0</int>
-													<int key="NSTickMarkPosition">1</int>
-													<bool key="NSAllowsTickMarkValuesOnly">NO</bool>
-													<bool key="NSVertical">NO</bool>
-												</object>
-											</object>
-											<object class="NSTextField" id="668219766">
-												<reference key="NSNextResponder" ref="343563030"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{14, 289}, {134, 17}}</string>
-												<reference key="NSSuperview" ref="343563030"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="89216511">
-													<int key="NSCellFlags">68288064</int>
-													<int key="NSCellFlags2">71304192</int>
-													<string key="NSContents">Total Candidates:</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="668219766"/>
-													<reference key="NSBackgroundColor" ref="126660839"/>
-													<reference key="NSTextColor" ref="441432662"/>
-												</object>
-											</object>
-											<object class="NSComboBox" id="1049256708">
-												<reference key="NSNextResponder" ref="343563030"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{161, 282}, {95, 26}}</string>
-												<reference key="NSSuperview" ref="343563030"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSComboBoxCell" key="NSCell" id="646685297">
-													<int key="NSCellFlags">74579521</int>
-													<int key="NSCellFlags2">272630784</int>
-													<string key="NSContents">9</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="1049256708"/>
-													<bool key="NSDrawsBackground">YES</bool>
-													<object class="NSColor" key="NSBackgroundColor" id="480063799">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">textBackgroundColor</string>
-														<reference key="NSColor" ref="839116681"/>
-													</object>
-													<reference key="NSTextColor" ref="441432662"/>
-													<int key="NSVisibleItemCount">6</int>
-													<bool key="NSHasVerticalScroller">YES</bool>
-													<object class="NSMutableArray" key="NSPopUpListData">
-														<bool key="EncodedWithXMLCoder">YES</bool>
-														<string>4</string>
-														<string>5</string>
-														<string>6</string>
-														<string>7</string>
-														<string>8</string>
-														<string>9</string>
-													</object>
-													<reference key="NSDelegate" ref="1049256708"/>
-													<object class="NSComboTableView" key="NSTableView" id="799682394">
-														<reference key="NSNextResponder"/>
-														<int key="NSvFlags">274</int>
-														<string key="NSFrameSize">{13, 126}</string>
-														<reference key="NSSuperview"/>
-														<reference key="NSWindow"/>
-														<bool key="NSEnabled">YES</bool>
-														<object class="NSMutableArray" key="NSTableColumns">
-															<bool key="EncodedWithXMLCoder">YES</bool>
-															<object class="NSTableColumn">
-																<double key="NSWidth">10</double>
-																<double key="NSMinWidth">10</double>
-																<double key="NSMaxWidth">1000</double>
-																<object class="NSTableHeaderCell" key="NSHeaderCell">
-																	<int key="NSCellFlags">75628032</int>
-																	<int key="NSCellFlags2">0</int>
-																	<string key="NSContents"/>
-																	<object class="NSFont" key="NSSupport" id="656546831">
-																		<string key="NSName">LucidaGrande</string>
-																		<double key="NSSize">12</double>
-																		<int key="NSfFlags">16</int>
-																	</object>
-																	<object class="NSColor" key="NSBackgroundColor">
-																		<int key="NSColorSpace">3</int>
-																		<bytes key="NSWhite">MC4zMzMzMzI5OQA</bytes>
-																	</object>
-																	<reference key="NSTextColor" ref="839116681"/>
-																</object>
-																<object class="NSTextFieldCell" key="NSDataCell">
-																	<int key="NSCellFlags">1412562496</int>
-																	<int key="NSCellFlags2">1024</int>
-																	<string key="NSContents">9</string>
-																	<reference key="NSSupport" ref="197917625"/>
-																	<reference key="NSControlView" ref="799682394"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<object class="NSColor" key="NSBackgroundColor" id="687272853">
-																		<int key="NSColorSpace">6</int>
-																		<string key="NSCatalogName">System</string>
-																		<string key="NSColorName">controlBackgroundColor</string>
-																		<reference key="NSColor" ref="92692141"/>
-																	</object>
-																	<reference key="NSTextColor" ref="441432662"/>
-																</object>
-																<int key="NSResizingMask">3</int>
-																<bool key="NSIsResizeable">YES</bool>
-																<reference key="NSTableView" ref="799682394"/>
-															</object>
-														</object>
-														<double key="NSIntercellSpacingWidth">3</double>
-														<double key="NSIntercellSpacingHeight">2</double>
-														<reference key="NSBackgroundColor" ref="687272853"/>
-														<object class="NSColor" key="NSGridColor" id="253207823">
-															<int key="NSColorSpace">6</int>
-															<string key="NSCatalogName">System</string>
-															<string key="NSColorName">gridColor</string>
-															<object class="NSColor" key="NSColor">
-																<int key="NSColorSpace">3</int>
-																<bytes key="NSWhite">MC41AA</bytes>
-															</object>
-														</object>
-														<double key="NSRowHeight">19</double>
-														<string key="NSAction">tableViewAction:</string>
-														<int key="NSTvFlags">-765427712</int>
-														<reference key="NSDelegate" ref="646685297"/>
-														<reference key="NSDataSource" ref="646685297"/>
-														<reference key="NSTarget" ref="646685297"/>
-														<int key="NSColumnAutoresizingStyle">1</int>
-														<int key="NSDraggingSourceMaskForLocal">15</int>
-														<int key="NSDraggingSourceMaskForNonLocal">0</int>
-														<bool key="NSAllowsTypeSelect">YES</bool>
-														<int key="NSTableViewDraggingDestinationStyle">0</int>
-														<int key="NSTableViewGroupRowStyle">1</int>
-													</object>
-												</object>
-											</object>
-											<object class="NSTextField" id="649100559">
-												<reference key="NSNextResponder" ref="343563030"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{161, 248}, {118, 22}}</string>
-												<reference key="NSSuperview" ref="343563030"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="64731394">
-													<int key="NSCellFlags">-2077098431</int>
-													<int key="NSCellFlags2">138413056</int>
-													<string key="NSContents">Hei 16</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="649100559"/>
-													<bool key="NSDrawsBackground">YES</bool>
-													<reference key="NSBackgroundColor" ref="149652997"/>
-													<object class="NSColor" key="NSTextColor">
-														<int key="NSColorSpace">1</int>
-														<bytes key="NSRGB">MSAxIDEAA</bytes>
-													</object>
-												</object>
-											</object>
-											<object class="NSTextField" id="450134849">
-												<reference key="NSNextResponder" ref="343563030"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{23, 326}, {125, 17}}</string>
-												<reference key="NSSuperview" ref="343563030"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="163163325">
-													<int key="NSCellFlags">68288064</int>
-													<int key="NSCellFlags2">71304192</int>
-													<string key="NSContents">Candidate Charset:</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="450134849"/>
-													<reference key="NSBackgroundColor" ref="126660839"/>
-													<reference key="NSTextColor" ref="441432662"/>
-												</object>
-											</object>
-											<object class="NSComboBox" id="676957937">
-												<reference key="NSNextResponder" ref="343563030"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{161, 319}, {95, 26}}</string>
-												<reference key="NSSuperview" ref="343563030"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSComboBoxCell" key="NSCell" id="94299120">
-													<int key="NSCellFlags">74579521</int>
-													<int key="NSCellFlags2">272630784</int>
-													<string key="NSContents">GB2312</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="676957937"/>
-													<bool key="NSDrawsBackground">YES</bool>
-													<reference key="NSBackgroundColor" ref="480063799"/>
-													<reference key="NSTextColor" ref="441432662"/>
-													<int key="NSVisibleItemCount">5</int>
-													<bool key="NSHasVerticalScroller">YES</bool>
-													<object class="NSMutableArray" key="NSPopUpListData">
-														<bool key="EncodedWithXMLCoder">YES</bool>
-														<string>GB2312</string>
-														<string>GBK</string>
-														<string>GB18030</string>
-													</object>
-													<reference key="NSDelegate" ref="676957937"/>
-													<object class="NSComboTableView" key="NSTableView" id="396061143">
-														<reference key="NSNextResponder"/>
-														<int key="NSvFlags">274</int>
-														<string key="NSFrameSize">{13, 63}</string>
-														<reference key="NSSuperview"/>
-														<reference key="NSWindow"/>
-														<bool key="NSEnabled">YES</bool>
-														<object class="NSMutableArray" key="NSTableColumns">
-															<bool key="EncodedWithXMLCoder">YES</bool>
-															<object class="NSTableColumn">
-																<double key="NSWidth">10</double>
-																<double key="NSMinWidth">10</double>
-																<double key="NSMaxWidth">1000</double>
-																<object class="NSTableHeaderCell" key="NSHeaderCell">
-																	<int key="NSCellFlags">75628032</int>
-																	<int key="NSCellFlags2">0</int>
-																	<string key="NSContents"/>
-																	<reference key="NSSupport" ref="656546831"/>
-																	<object class="NSColor" key="NSBackgroundColor">
-																		<int key="NSColorSpace">3</int>
-																		<bytes key="NSWhite">MC4zMzMzMzI5OQA</bytes>
-																	</object>
-																	<reference key="NSTextColor" ref="839116681"/>
-																</object>
-																<object class="NSTextFieldCell" key="NSDataCell">
-																	<int key="NSCellFlags">338820672</int>
-																	<int key="NSCellFlags2">268436480</int>
-																	<string key="NSContents">GBK</string>
-																	<reference key="NSSupport" ref="197917625"/>
-																	<reference key="NSControlView" ref="396061143"/>
-																	<bool key="NSDrawsBackground">YES</bool>
-																	<reference key="NSBackgroundColor" ref="687272853"/>
-																	<reference key="NSTextColor" ref="441432662"/>
-																</object>
-																<int key="NSResizingMask">3</int>
-																<bool key="NSIsResizeable">YES</bool>
-																<reference key="NSTableView" ref="396061143"/>
-															</object>
-														</object>
-														<double key="NSIntercellSpacingWidth">3</double>
-														<double key="NSIntercellSpacingHeight">2</double>
-														<reference key="NSBackgroundColor" ref="687272853"/>
-														<reference key="NSGridColor" ref="253207823"/>
-														<double key="NSRowHeight">19</double>
-														<string key="NSAction">tableViewAction:</string>
-														<int key="NSTvFlags">-765427712</int>
-														<reference key="NSDelegate" ref="94299120"/>
-														<reference key="NSDataSource" ref="94299120"/>
-														<reference key="NSTarget" ref="94299120"/>
-														<int key="NSColumnAutoresizingStyle">1</int>
-														<int key="NSDraggingSourceMaskForLocal">15</int>
-														<int key="NSDraggingSourceMaskForNonLocal">0</int>
-														<bool key="NSAllowsTypeSelect">YES</bool>
-														<int key="NSTableViewDraggingDestinationStyle">0</int>
-														<int key="NSTableViewGroupRowStyle">1</int>
-													</object>
-												</object>
-											</object>
-											<object class="NSColorWell" id="913967279">
-												<reference key="NSNextResponder" ref="343563030"/>
-												<int key="NSvFlags">268</int>
-												<object class="NSMutableSet" key="NSDragTypes">
-													<bool key="EncodedWithXMLCoder">YES</bool>
-													<object class="NSArray" key="set.sortedObjects">
-														<bool key="EncodedWithXMLCoder">YES</bool>
-														<string>NSColor pasteboard type</string>
-													</object>
-												</object>
-												<string key="NSFrame">{{161, 174}, {92, 23}}</string>
-												<reference key="NSSuperview" ref="343563030"/>
-												<bool key="NSEnabled">YES</bool>
-												<bool key="NSIsBordered">YES</bool>
-												<object class="NSColor" key="NSColor">
-													<int key="NSColorSpace">1</int>
-													<bytes key="NSRGB">MC4wNTgxMzA0OTkgMC4wNTU1NDE4OTkgMQA</bytes>
-												</object>
-											</object>
-										</object>
-										<string key="NSFrame">{{10, 33}, {386, 357}}</string>
-									</object>
-									<string key="NSLabel">Candidates</string>
-									<reference key="NSColor" ref="126660839"/>
-									<reference key="NSTabView" ref="920744728"/>
-								</object>
-								<object class="NSTabViewItem" id="200766654">
-									<string key="NSIdentifier">Item 3</string>
-									<object class="NSView" key="NSView" id="725427137">
-										<nil key="NSNextResponder"/>
-										<int key="NSvFlags">256</int>
-										<object class="NSMutableArray" key="NSSubviews">
-											<bool key="EncodedWithXMLCoder">YES</bool>
-											<object class="NSScrollView" id="53152157">
-												<reference key="NSNextResponder" ref="725427137"/>
-												<int key="NSvFlags">268</int>
-												<object class="NSMutableArray" key="NSSubviews">
-													<bool key="EncodedWithXMLCoder">YES</bool>
-													<object class="NSClipView" id="344556229">
-														<reference key="NSNextResponder" ref="53152157"/>
-														<int key="NSvFlags">2304</int>
-														<object class="NSMutableArray" key="NSSubviews">
-															<bool key="EncodedWithXMLCoder">YES</bool>
-															<object class="NSTableView" id="788144279">
-																<reference key="NSNextResponder" ref="344556229"/>
-																<int key="NSvFlags">256</int>
-																<string key="NSFrameSize">{350, 335}</string>
-																<reference key="NSSuperview" ref="344556229"/>
-																<reference key="NSNextKeyView" ref="950456908"/>
-																<bool key="NSEnabled">YES</bool>
-																<object class="NSTableHeaderView" key="NSHeaderView" id="839026685">
-																	<reference key="NSNextResponder" ref="120446450"/>
-																	<int key="NSvFlags">256</int>
-																	<string key="NSFrameSize">{350, 17}</string>
-																	<reference key="NSSuperview" ref="120446450"/>
-																	<reference key="NSNextKeyView" ref="344556229"/>
-																	<reference key="NSTableView" ref="788144279"/>
-																</object>
-																<object class="_NSCornerView" key="NSCornerView">
-																	<nil key="NSNextResponder"/>
-																	<int key="NSvFlags">-2147483392</int>
-																	<string key="NSFrame">{{224, 0}, {16, 17}}</string>
-																</object>
-																<object class="NSMutableArray" key="NSTableColumns">
-																	<bool key="EncodedWithXMLCoder">YES</bool>
-																	<object class="NSTableColumn" id="650465578">
-																		<string key="NSIdentifier">column1</string>
-																		<double key="NSWidth">55</double>
-																		<double key="NSMinWidth">40</double>
-																		<double key="NSMaxWidth">1000</double>
-																		<object class="NSTableHeaderCell" key="NSHeaderCell">
-																			<int key="NSCellFlags">75628096</int>
-																			<int key="NSCellFlags2">2048</int>
-																			<string key="NSContents"/>
-																			<object class="NSFont" key="NSSupport" id="26">
-																				<string key="NSName">LucidaGrande</string>
-																				<double key="NSSize">11</double>
-																				<int key="NSfFlags">3100</int>
-																			</object>
-																			<object class="NSColor" key="NSBackgroundColor" id="225764018">
-																				<int key="NSColorSpace">3</int>
-																				<bytes key="NSWhite">MC4zMzMzMzI5ODU2AA</bytes>
-																			</object>
-																			<object class="NSColor" key="NSTextColor" id="851993477">
-																				<int key="NSColorSpace">6</int>
-																				<string key="NSCatalogName">System</string>
-																				<string key="NSColorName">headerTextColor</string>
-																				<reference key="NSColor" ref="343701635"/>
-																			</object>
-																		</object>
-																		<object class="NSButtonCell" key="NSDataCell" id="952921586">
-																			<int key="NSCellFlags">67239424</int>
-																			<int key="NSCellFlags2">0</int>
-																			<string key="NSContents"/>
-																			<reference key="NSSupport" ref="197917625"/>
-																			<reference key="NSControlView" ref="788144279"/>
-																			<int key="NSButtonFlags">1211912703</int>
-																			<int key="NSButtonFlags2">2</int>
-																			<reference key="NSNormalImage" ref="999525749"/>
-																			<reference key="NSAlternateImage" ref="376999508"/>
-																			<string key="NSAlternateContents"/>
-																			<string key="NSKeyEquivalent"/>
-																			<int key="NSPeriodicDelay">200</int>
-																			<int key="NSPeriodicInterval">25</int>
-																		</object>
-																		<int key="NSResizingMask">3</int>
-																		<bool key="NSIsResizeable">YES</bool>
-																		<bool key="NSIsEditable">YES</bool>
-																		<reference key="NSTableView" ref="788144279"/>
-																	</object>
-																	<object class="NSTableColumn" id="400622282">
-																		<string key="NSIdentifier">column2</string>
-																		<double key="NSWidth">123</double>
-																		<double key="NSMinWidth">40</double>
-																		<double key="NSMaxWidth">1000</double>
-																		<object class="NSTableHeaderCell" key="NSHeaderCell">
-																			<int key="NSCellFlags">75628096</int>
-																			<int key="NSCellFlags2">2048</int>
-																			<string key="NSContents">ASCII Character</string>
-																			<reference key="NSSupport" ref="26"/>
-																			<reference key="NSBackgroundColor" ref="225764018"/>
-																			<reference key="NSTextColor" ref="851993477"/>
-																		</object>
-																		<object class="NSTextFieldCell" key="NSDataCell" id="236435869">
-																			<int key="NSCellFlags">337772096</int>
-																			<int key="NSCellFlags2">2048</int>
-																			<string key="NSContents">Text Cell</string>
-																			<reference key="NSSupport" ref="197917625"/>
-																			<reference key="NSControlView" ref="788144279"/>
-																			<reference key="NSBackgroundColor" ref="687272853"/>
-																			<reference key="NSTextColor" ref="441432662"/>
-																		</object>
-																		<int key="NSResizingMask">3</int>
-																		<bool key="NSIsResizeable">YES</bool>
-																		<reference key="NSTableView" ref="788144279"/>
-																	</object>
-																	<object class="NSTableColumn" id="128275113">
-																		<string key="NSIdentifier">column3</string>
-																		<double key="NSWidth">163</double>
-																		<double key="NSMinWidth">10</double>
-																		<double key="NSMaxWidth">3.4028234663852886e+38</double>
-																		<object class="NSTableHeaderCell" key="NSHeaderCell">
-																			<int key="NSCellFlags">75628096</int>
-																			<int key="NSCellFlags2">2048</int>
-																			<string key="NSContents">Mapped String</string>
-																			<reference key="NSSupport" ref="26"/>
-																			<object class="NSColor" key="NSBackgroundColor">
-																				<int key="NSColorSpace">6</int>
-																				<string key="NSCatalogName">System</string>
-																				<string key="NSColorName">headerColor</string>
-																				<reference key="NSColor" ref="839116681"/>
-																			</object>
-																			<reference key="NSTextColor" ref="851993477"/>
-																		</object>
-																		<object class="NSTextFieldCell" key="NSDataCell" id="615487221">
-																			<int key="NSCellFlags">337772096</int>
-																			<int key="NSCellFlags2">2048</int>
-																			<string key="NSContents">Text Cell</string>
-																			<reference key="NSSupport" ref="197917625"/>
-																			<reference key="NSControlView" ref="788144279"/>
-																			<reference key="NSBackgroundColor" ref="687272853"/>
-																			<reference key="NSTextColor" ref="441432662"/>
-																		</object>
-																		<int key="NSResizingMask">3</int>
-																		<bool key="NSIsResizeable">YES</bool>
-																		<bool key="NSIsEditable">YES</bool>
-																		<reference key="NSTableView" ref="788144279"/>
-																	</object>
-																</object>
-																<double key="NSIntercellSpacingWidth">3</double>
-																<double key="NSIntercellSpacingHeight">2</double>
-																<reference key="NSBackgroundColor" ref="839116681"/>
-																<reference key="NSGridColor" ref="253207823"/>
-																<double key="NSRowHeight">17</double>
-																<int key="NSTvFlags">-700448768</int>
-																<reference key="NSDelegate"/>
-																<reference key="NSDataSource"/>
-																<int key="NSColumnAutoresizingStyle">4</int>
-																<int key="NSDraggingSourceMaskForLocal">15</int>
-																<int key="NSDraggingSourceMaskForNonLocal">0</int>
-																<bool key="NSAllowsTypeSelect">YES</bool>
-																<int key="NSTableViewDraggingDestinationStyle">0</int>
-																<int key="NSTableViewGroupRowStyle">1</int>
-															</object>
-														</object>
-														<string key="NSFrame">{{1, 17}, {350, 335}}</string>
-														<reference key="NSSuperview" ref="53152157"/>
-														<reference key="NSNextKeyView" ref="788144279"/>
-														<reference key="NSDocView" ref="788144279"/>
-														<reference key="NSBGColor" ref="687272853"/>
-														<int key="NScvFlags">4</int>
-													</object>
-													<object class="NSScroller" id="297985295">
-														<reference key="NSNextResponder" ref="53152157"/>
-														<int key="NSvFlags">-2147483392</int>
-														<string key="NSFrame">{{224, 17}, {15, 102}}</string>
-														<reference key="NSSuperview" ref="53152157"/>
-														<reference key="NSTarget" ref="53152157"/>
-														<string key="NSAction">_doScroller:</string>
-														<double key="NSPercent">0.99596774193548387</double>
-													</object>
-													<object class="NSScroller" id="950456908">
-														<reference key="NSNextResponder" ref="53152157"/>
-														<int key="NSvFlags">-2147483392</int>
-														<string key="NSFrame">{{-100, -100}, {247, 15}}</string>
-														<reference key="NSSuperview" ref="53152157"/>
-														<reference key="NSNextKeyView" ref="120446450"/>
-														<int key="NSsFlags">1</int>
-														<reference key="NSTarget" ref="53152157"/>
-														<string key="NSAction">_doScroller:</string>
-														<double key="NSPercent">0.9971509971509972</double>
-													</object>
-													<object class="NSClipView" id="120446450">
-														<reference key="NSNextResponder" ref="53152157"/>
-														<int key="NSvFlags">2304</int>
-														<object class="NSMutableArray" key="NSSubviews">
-															<bool key="EncodedWithXMLCoder">YES</bool>
-															<reference ref="839026685"/>
-														</object>
-														<string key="NSFrame">{{1, 0}, {350, 17}}</string>
-														<reference key="NSSuperview" ref="53152157"/>
-														<reference key="NSNextKeyView" ref="839026685"/>
-														<reference key="NSDocView" ref="839026685"/>
-														<reference key="NSBGColor" ref="687272853"/>
-														<int key="NScvFlags">4</int>
-													</object>
-												</object>
-												<string key="NSFrame">{{17, -3}, {352, 353}}</string>
-												<reference key="NSSuperview" ref="725427137"/>
-												<reference key="NSNextKeyView" ref="344556229"/>
-												<int key="NSsFlags">133650</int>
-												<reference key="NSVScroller" ref="297985295"/>
-												<reference key="NSHScroller" ref="950456908"/>
-												<reference key="NSContentView" ref="344556229"/>
-												<reference key="NSHeaderClipView" ref="120446450"/>
-												<bytes key="NSScrollAmts">QSAAAEEgAABBmAAAQZgAAA</bytes>
-											</object>
-										</object>
-										<string key="NSFrame">{{10, 33}, {386, 357}}</string>
-										<reference key="NSNextKeyView" ref="53152157"/>
-									</object>
-									<string key="NSLabel">Punctations</string>
-									<reference key="NSColor" ref="126660839"/>
-									<reference key="NSTabView" ref="920744728"/>
-								</object>
-								<object class="NSTabViewItem" id="718470466">
-									<string key="NSIdentifier">Item 4</string>
-									<object class="NSView" key="NSView" id="404366215">
-										<nil key="NSNextResponder"/>
-										<int key="NSvFlags">256</int>
-										<object class="NSMutableArray" key="NSSubviews">
-											<bool key="EncodedWithXMLCoder">YES</bool>
-											<object class="NSButton" id="426394681">
-												<reference key="NSNextResponder" ref="404366215"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{11, 9}, {166, 32}}</string>
-												<reference key="NSSuperview" ref="404366215"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="999022373">
-													<int key="NSCellFlags">67239424</int>
-													<int key="NSCellFlags2">134217728</int>
-													<string key="NSContents">Check for Updates...</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="426394681"/>
-													<int key="NSButtonFlags">-2038284033</int>
-													<int key="NSButtonFlags2">129</int>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSButton" id="6795274">
-												<reference key="NSNextResponder" ref="404366215"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{177, 18}, {199, 18}}</string>
-												<reference key="NSSuperview" ref="404366215"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSButtonCell" key="NSCell" id="1033602394">
-													<int key="NSCellFlags">-2080244224</int>
-													<int key="NSCellFlags2">0</int>
-													<string key="NSContents">Check automatically</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="6795274"/>
-													<int key="NSButtonFlags">1211912703</int>
-													<int key="NSButtonFlags2">2</int>
-													<reference key="NSNormalImage" ref="999525749"/>
-													<reference key="NSAlternateImage" ref="376999508"/>
-													<string key="NSAlternateContents"/>
-													<string key="NSKeyEquivalent"/>
-													<int key="NSPeriodicDelay">200</int>
-													<int key="NSPeriodicInterval">25</int>
-												</object>
-											</object>
-											<object class="NSTextField" id="572714115">
-												<reference key="NSNextResponder" ref="404366215"/>
-												<int key="NSvFlags">268</int>
-												<string key="NSFrame">{{17, 112}, {352, 233}}</string>
-												<reference key="NSSuperview" ref="404366215"/>
-												<bool key="NSEnabled">YES</bool>
-												<object class="NSTextFieldCell" key="NSCell" id="958503593">
-													<int key="NSCellFlags">-2080244224</int>
-													<int key="NSCellFlags2">138412032</int>
-													<string type="base64-UTF8" key="NSContents">VmVyc2lvbiAyLjAuMi4xMDA4CgpDb3B5cmlnaHQgwqkgMjAxMCBTdW5QaW55aW4uT1JHClN1biBNaWNy
-b3N5c3RlbXMsIEluYy4KTGVpIFpoYW5nIDxwaGlsbC56aGFuZ0BnbWFpbC5jb20+CllvbmcgU3VuIDxt
-YWlsQHlvbmdzdW4ubWU+CktlZnUgQ2hhaSA8dGNoYWlrb3ZAZ21haWwuY29tPgpXZWkgWHVlIDxicmVh
-ZHNvbi54dWVAZ21haWwuY29tPgpMZW8gWmhlbmcgPHp5bTM2MUBnbWFpbC5jb20+Ck1pa2UgPG1pa2Vh
-bmRtb3JlQGdtYWlsLmNvbT4KY2h1bXNkb2NrIDx2b3JiZWlAZ21haWwuY29tPgpBbnRob255IExlZSA8
-ZG9uLmFudGhvbnkubGVlQGdtYWlsLmNvbT4</string>
-													<reference key="NSSupport" ref="197917625"/>
-													<reference key="NSControlView" ref="572714115"/>
-													<reference key="NSBackgroundColor" ref="480063799"/>
-													<object class="NSColor" key="NSTextColor">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">textColor</string>
-														<reference key="NSColor" ref="343701635"/>
-													</object>
-												</object>
-											</object>
-										</object>
-										<string key="NSFrame">{{10, 33}, {386, 357}}</string>
-									</object>
-									<string key="NSLabel">About</string>
-									<reference key="NSColor" ref="126660839"/>
-									<reference key="NSTabView" ref="920744728"/>
-								</object>
-							</object>
-							<reference key="NSSelectedTabViewItem" ref="844599924"/>
-							<reference key="NSFont" ref="197917625"/>
-							<int key="NSTvFlags">0</int>
-							<bool key="NSAllowTruncatedLabels">YES</bool>
-							<bool key="NSDrawsBackground">YES</bool>
-							<object class="NSMutableArray" key="NSSubviews">
-								<bool key="EncodedWithXMLCoder">YES</bool>
-								<reference ref="556411416"/>
-							</object>
-						</object>
-					</object>
-					<string key="NSFrameSize">{432, 419}</string>
-					<reference key="NSSuperview"/>
-					<reference key="NSWindow"/>
-					<reference key="NSNextKeyView" ref="920744728"/>
-				</object>
-				<string key="NSScreenRect">{{0, 0}, {1440, 878}}</string>
-				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
-				<bool key="NSWindowIsRestorable">YES</bool>
-			</object>
-			<object class="NSUserDefaultsController" id="333442631">
-				<bool key="NSSharedInstance">YES</bool>
-			</object>
-			<object class="NSCustomObject" id="850400115">
-				<string key="NSClassName">SUUpdater</string>
-			</object>
-			<object class="NSArrayController" id="387553423">
-				<object class="NSMutableArray" key="NSDeclaredKeys">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-					<string>enabled</string>
-					<string>ASCII</string>
-					<string>mappedString</string>
-				</object>
-				<bool key="NSEditable">YES</bool>
-				<object class="_NSManagedProxy" key="_NSManagedProxy"/>
-				<bool key="NSAvoidsEmptySelection">YES</bool>
-				<bool key="NSPreservesSelection">YES</bool>
-				<bool key="NSSelectsInsertedObjects">YES</bool>
-				<bool key="NSFilterRestrictsInsertion">YES</bool>
-				<bool key="NSClearsFilterPredicateOnInsertion">YES</bool>
-			</object>
-		</object>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<object class="NSMutableArray" key="connectionRecords">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="839093953"/>
-						<reference key="destination" ref="57193187"/>
-					</object>
-					<int key="connectionID">253</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">_menu</string>
-						<reference key="source" ref="57193187"/>
-						<reference key="destination" ref="183480630"/>
-					</object>
-					<int key="connectionID">271</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">_candiWin</string>
-						<reference key="source" ref="57193187"/>
-						<reference key="destination" ref="61923071"/>
-					</object>
-					<int key="connectionID">275</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">showFontPanel:</string>
-						<reference key="source" ref="57193187"/>
-						<reference key="destination" ref="396267292"/>
-					</object>
-					<int key="connectionID">350</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">_prefPanel</string>
-						<reference key="source" ref="57193187"/>
-						<reference key="destination" ref="965753792"/>
-					</object>
-					<int key="connectionID">366</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">showPrefPanel:</string>
-						<reference key="source" ref="57193187"/>
-						<reference key="destination" ref="896308868"/>
-					</object>
-					<int key="connectionID">383</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.pagingByBrackets</string>
-						<reference key="source" ref="813143560"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="813143560"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.pagingByBrackets</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.pagingByBrackets</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">409</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.pagingByCommaAndDot</string>
-						<reference key="source" ref="319933815"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="319933815"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.pagingByCommaAndDot</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.pagingByCommaAndDot</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">411</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.alpha</string>
-						<reference key="source" ref="116399245"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="116399245"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.alpha</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.alpha</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">416</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.pagingByMinusAndEqual</string>
-						<reference key="source" ref="121487339"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="121487339"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.pagingByMinusAndEqual</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.pagingByMinusAndEqual</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">418</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.bgColor</string>
-						<reference key="source" ref="259224558"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="259224558"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.bgColor</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.bgColor</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSValueTransformerName</string>
-								<string key="NS.object.0">NSUnarchiveFromData</string>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">432</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.candiNumbers</string>
-						<reference key="source" ref="1049256708"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="1049256708"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.candiNumbers</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.candiNumbers</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">436</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">_ftTxtField</string>
-						<reference key="source" ref="57193187"/>
-						<reference key="destination" ref="649100559"/>
-					</object>
-					<int key="connectionID">437</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.inputChinesePuncts</string>
-						<reference key="source" ref="1072444278"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="1072444278"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.inputChinesePuncts</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.inputChinesePuncts</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">441</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">toggleChinesePuncts:</string>
-						<reference key="source" ref="57193187"/>
-						<reference key="destination" ref="1072444278"/>
-					</object>
-					<int key="connectionID">442</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">toggleFullSymbols:</string>
-						<reference key="source" ref="57193187"/>
-						<reference key="destination" ref="402399656"/>
-					</object>
-					<int key="connectionID">444</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.inputFullSymbols</string>
-						<reference key="source" ref="402399656"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="402399656"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.inputFullSymbols</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.inputFullSymbols</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">446</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.charset</string>
-						<reference key="source" ref="676957937"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="676957937"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.charset</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.charset</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">465</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.hlColor</string>
-						<reference key="source" ref="913967279"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="913967279"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.hlColor</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.hlColor</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSValueTransformerName</string>
-								<string key="NS.object.0">NSUnarchiveFromData</string>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">469</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.usingUSKbLayout</string>
-						<reference key="source" ref="110272516"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="110272516"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.usingUSKbLayout</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.usingUSKbLayout</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">480</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">selectedIndex: values.switchingPolicy</string>
-						<reference key="source" ref="696757669"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="696757669"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">selectedIndex: values.switchingPolicy</string>
-							<string key="NSBinding">selectedIndex</string>
-							<string key="NSKeyPath">values.switchingPolicy</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">490</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">selectedTag: values.pinyinMode</string>
-						<reference key="source" ref="588621662"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="588621662"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">selectedTag: values.pinyinMode</string>
-							<string key="NSBinding">selectedTag</string>
-							<string key="NSKeyPath">values.pinyinMode</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">564</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.Fuzzy.Enabled</string>
-						<reference key="source" ref="424806521"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="424806521"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.Fuzzy.Enabled</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">595</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.Fuzzy.ZhiZi</string>
-						<reference key="source" ref="319545690"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="319545690"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.Fuzzy.ZhiZi</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.ZhiZi</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">596</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.Fuzzy.ChiCi</string>
-						<reference key="source" ref="813582582"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="813582582"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.Fuzzy.ChiCi</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.ChiCi</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">597</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.Fuzzy.ShiSi</string>
-						<reference key="source" ref="966132901"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="966132901"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.Fuzzy.ShiSi</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.ShiSi</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">598</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.Fuzzy.AnAng</string>
-						<reference key="source" ref="648858317"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="648858317"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.Fuzzy.AnAng</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.AnAng</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">599</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.Fuzzy.OnOng</string>
-						<reference key="source" ref="862308995"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="862308995"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.Fuzzy.OnOng</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.OnOng</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">600</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.Fuzzy.EnEng</string>
-						<reference key="source" ref="262821321"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="262821321"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.Fuzzy.EnEng</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.EnEng</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">601</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.Fuzzy.InIng</string>
-						<reference key="source" ref="878656198"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="878656198"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.Fuzzy.InIng</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.InIng</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">602</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.Fuzzy.EngOng</string>
-						<reference key="source" ref="918479979"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="918479979"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.Fuzzy.EngOng</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.EngOng</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">603</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.Fuzzy.IanIang</string>
-						<reference key="source" ref="55673680"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="55673680"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.Fuzzy.IanIang</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.IanIang</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">604</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.Fuzzy.UanUang</string>
-						<reference key="source" ref="795322137"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="795322137"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.Fuzzy.UanUang</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.UanUang</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">605</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.Fuzzy.NeLe</string>
-						<reference key="source" ref="853626170"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="853626170"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.Fuzzy.NeLe</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.NeLe</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">606</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.Fuzzy.FoHe</string>
-						<reference key="source" ref="1064523668"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="1064523668"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.Fuzzy.FoHe</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.FoHe</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">607</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.Fuzzy.LeRi</string>
-						<reference key="source" ref="201490911"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="201490911"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.Fuzzy.LeRi</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.LeRi</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">608</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.Fuzzy.KeGe</string>
-						<reference key="source" ref="676075530"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="676075530"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.Fuzzy.KeGe</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.KeGe</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">609</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.AutoCorrecting.Enabled</string>
-						<reference key="source" ref="60275823"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="60275823"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.AutoCorrecting.Enabled</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.AutoCorrecting.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">610</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.AutoCorrecting.ImgIng</string>
-						<reference key="source" ref="630653599"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="630653599"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.AutoCorrecting.ImgIng</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.AutoCorrecting.ImgIng</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">612</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.AutoCorrecting.UeiUi</string>
-						<reference key="source" ref="587691603"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="587691603"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.AutoCorrecting.UeiUi</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.AutoCorrecting.UeiUi</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">613</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.AutoCorrecting.UenUn</string>
-						<reference key="source" ref="517511508"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="517511508"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.AutoCorrecting.UenUn</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.AutoCorrecting.UenUn</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">614</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.AutoCorrecting.IouIu</string>
-						<reference key="source" ref="123364609"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="123364609"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.AutoCorrecting.IouIu</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.AutoCorrecting.IouIu</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">615</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">selectedIndex: values.Shuangpin.Scheme</string>
-						<reference key="source" ref="260441203"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="260441203"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">selectedIndex: values.Shuangpin.Scheme</string>
-							<string key="NSBinding">selectedIndex</string>
-							<string key="NSKeyPath">values.Shuangpin.Scheme</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">616</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.Quanpin.Fuzzy.Enabled</string>
-						<reference key="source" ref="319545690"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="319545690"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.Quanpin.Fuzzy.Enabled</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">640</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.Quanpin.Fuzzy.Enabled</string>
-						<reference key="source" ref="966132901"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="966132901"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.Quanpin.Fuzzy.Enabled</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">643</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.Quanpin.Fuzzy.Enabled</string>
-						<reference key="source" ref="648858317"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="648858317"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.Quanpin.Fuzzy.Enabled</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">644</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.Quanpin.Fuzzy.Enabled</string>
-						<reference key="source" ref="862308995"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="862308995"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.Quanpin.Fuzzy.Enabled</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">645</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.Quanpin.Fuzzy.Enabled</string>
-						<reference key="source" ref="262821321"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="262821321"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.Quanpin.Fuzzy.Enabled</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">646</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.Quanpin.Fuzzy.Enabled</string>
-						<reference key="source" ref="878656198"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="878656198"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.Quanpin.Fuzzy.Enabled</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">647</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.Quanpin.Fuzzy.Enabled</string>
-						<reference key="source" ref="918479979"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="918479979"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.Quanpin.Fuzzy.Enabled</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">648</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.Quanpin.Fuzzy.Enabled</string>
-						<reference key="source" ref="55673680"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="55673680"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.Quanpin.Fuzzy.Enabled</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">650</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.Quanpin.Fuzzy.Enabled</string>
-						<reference key="source" ref="795322137"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="795322137"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.Quanpin.Fuzzy.Enabled</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">652</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.Quanpin.Fuzzy.Enabled</string>
-						<reference key="source" ref="853626170"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="853626170"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.Quanpin.Fuzzy.Enabled</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">653</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.Quanpin.Fuzzy.Enabled</string>
-						<reference key="source" ref="1064523668"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="1064523668"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.Quanpin.Fuzzy.Enabled</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">655</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.Quanpin.Fuzzy.Enabled</string>
-						<reference key="source" ref="201490911"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="201490911"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.Quanpin.Fuzzy.Enabled</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">656</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.Quanpin.Fuzzy.Enabled</string>
-						<reference key="source" ref="676075530"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="676075530"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.Quanpin.Fuzzy.Enabled</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">659</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.Quanpin.AutoCorrecting.Enabled</string>
-						<reference key="source" ref="380966888"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="380966888"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.Quanpin.AutoCorrecting.Enabled</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.Quanpin.AutoCorrecting.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">660</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.Quanpin.AutoCorrecting.Enabled</string>
-						<reference key="source" ref="517511508"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="517511508"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.Quanpin.AutoCorrecting.Enabled</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.Quanpin.AutoCorrecting.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">662</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.Quanpin.AutoCorrecting.Enabled</string>
-						<reference key="source" ref="630653599"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="630653599"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.Quanpin.AutoCorrecting.Enabled</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.Quanpin.AutoCorrecting.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">664</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.Quanpin.AutoCorrecting.Enabled</string>
-						<reference key="source" ref="123364609"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="123364609"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.Quanpin.AutoCorrecting.Enabled</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.Quanpin.AutoCorrecting.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">665</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.Quanpin.AutoCorrecting.Enabled</string>
-						<reference key="source" ref="587691603"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="587691603"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.Quanpin.AutoCorrecting.Enabled</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.Quanpin.AutoCorrecting.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">667</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.Quanpin.Fuzzy.Enabled</string>
-						<reference key="source" ref="813582582"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="813582582"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.Quanpin.Fuzzy.Enabled</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">668</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.pinyinMode</string>
-						<reference key="source" ref="260441203"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="260441203"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.pinyinMode</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.pinyinMode</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">672</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">selectedIndex: values.commitPolicy</string>
-						<reference key="source" ref="1036969072"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="1036969072"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">selectedIndex: values.commitPolicy</string>
-							<string key="NSBinding">selectedIndex</string>
-							<string key="NSKeyPath">values.commitPolicy</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">682</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.switchingPolicy</string>
-						<reference key="source" ref="236533845"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="236533845"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.switchingPolicy</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.switchingPolicy</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">688</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: arrangedObjects.enabled</string>
-						<reference key="source" ref="650465578"/>
-						<reference key="destination" ref="387553423"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="650465578"/>
-							<reference key="NSDestination" ref="387553423"/>
-							<string key="NSLabel">value: arrangedObjects.enabled</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">arrangedObjects.enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">715</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: arrangedObjects.ASCII</string>
-						<reference key="source" ref="400622282"/>
-						<reference key="destination" ref="387553423"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="400622282"/>
-							<reference key="NSDestination" ref="387553423"/>
-							<string key="NSLabel">value: arrangedObjects.ASCII</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">arrangedObjects.ASCII</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSConditionallySetsEditable</string>
-								<boolean value="YES" key="NS.object.0"/>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">717</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: arrangedObjects.mappedString</string>
-						<reference key="source" ref="128275113"/>
-						<reference key="destination" ref="387553423"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="128275113"/>
-							<reference key="NSDestination" ref="387553423"/>
-							<string key="NSLabel">value: arrangedObjects.mappedString</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">arrangedObjects.mappedString</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">719</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">contentArray: values.punctationMappings</string>
-						<reference key="source" ref="387553423"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="387553423"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">contentArray: values.punctationMappings</string>
-							<string key="NSBinding">contentArray</string>
-							<string key="NSKeyPath">values.punctationMappings</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSHandlesContentAsCompoundValue</string>
-								<boolean value="YES" key="NS.object.0"/>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">720</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.radius</string>
-						<reference key="source" ref="565681738"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="565681738"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.radius</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.radius</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">726</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.pagingByArrowUpAndDown</string>
-						<reference key="source" ref="453322497"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="453322497"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.pagingByArrowUpAndDown</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.pagingByArrowUpAndDown</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">730</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">checkForUpdates:</string>
-						<reference key="source" ref="850400115"/>
-						<reference key="destination" ref="426394681"/>
-					</object>
-					<int key="connectionID">737</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.SUEnableAutomaticChecks</string>
-						<reference key="source" ref="6795274"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="6795274"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.SUEnableAutomaticChecks</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.SUEnableAutomaticChecks</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">738</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.AutoCorrecting.GnNg</string>
-						<reference key="source" ref="380966888"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="380966888"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.AutoCorrecting.GnNg</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.AutoCorrecting.GnNg</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">744</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.FuzzySegs.Enabled</string>
-						<reference key="source" ref="903629445"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="903629445"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.FuzzySegs.Enabled</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.FuzzySegs.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">750</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.Fuzzy.SimplerInitials</string>
-						<reference key="source" ref="876130661"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="876130661"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.Fuzzy.SimplerInitials</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.Fuzzy.SimplerInitials</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">755</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.Quanpin.FuzzySegs.InnerFuzzy.Enabled</string>
-						<reference key="source" ref="217309235"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="217309235"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.Quanpin.FuzzySegs.InnerFuzzy.Enabled</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.Quanpin.FuzzySegs.InnerFuzzy.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">759</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: values.Quanpin.FuzzySegs.Enabled</string>
-						<reference key="source" ref="217309235"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="217309235"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">enabled: values.Quanpin.FuzzySegs.Enabled</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">values.Quanpin.FuzzySegs.Enabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">761</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.cancelSelectionOnBackspace</string>
-						<reference key="source" ref="539388088"/>
-						<reference key="destination" ref="333442631"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="539388088"/>
-							<reference key="NSDestination" ref="333442631"/>
-							<string key="NSLabel">value: values.cancelSelectionOnBackspace</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.cancelSelectionOnBackspace</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">768</int>
-				</object>
-			</object>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<object class="NSArray" key="orderedObjects">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<reference key="object" ref="0"/>
-						<reference key="children" ref="602786588"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="839093953"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="504355175"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">First Responder</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-3</int>
-						<reference key="object" ref="517753632"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Application</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">252</int>
-						<reference key="object" ref="57193187"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">SunPinyinApplicationDelegate</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">268</int>
-						<reference key="object" ref="183480630"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="896308868"/>
-							<reference ref="1072444278"/>
-							<reference ref="402399656"/>
-						</object>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Menu (Menu)</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">269</int>
-						<reference key="object" ref="896308868"/>
-						<reference key="parent" ref="183480630"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">273</int>
-						<reference key="object" ref="61923071"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">CandidateWindow</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">277</int>
-						<reference key="object" ref="965753792"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="881402259"/>
-						</object>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">PrefPanel (Panel)</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">278</int>
-						<reference key="object" ref="881402259"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="920744728"/>
-						</object>
-						<reference key="parent" ref="965753792"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">279</int>
-						<reference key="object" ref="920744728"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="844599924"/>
-							<reference ref="79480864"/>
-							<reference ref="235566413"/>
-							<reference ref="200766654"/>
-							<reference ref="718470466"/>
-						</object>
-						<reference key="parent" ref="881402259"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">280</int>
-						<reference key="object" ref="235566413"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="343563030"/>
-						</object>
-						<reference key="parent" ref="920744728"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">298</int>
-						<reference key="object" ref="343563030"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="259224558"/>
-							<reference ref="668219766"/>
-							<reference ref="1049256708"/>
-							<reference ref="649100559"/>
-							<reference ref="676957937"/>
-							<reference ref="396267292"/>
-							<reference ref="450134849"/>
-							<reference ref="387956930"/>
-							<reference ref="706521650"/>
-							<reference ref="658605159"/>
-							<reference ref="293499524"/>
-							<reference ref="913967279"/>
-							<reference ref="344543120"/>
-							<reference ref="840782193"/>
-							<reference ref="921987807"/>
-						</object>
-						<reference key="parent" ref="235566413"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">299</int>
-						<reference key="object" ref="1049256708"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="646685297"/>
-						</object>
-						<reference key="parent" ref="343563030"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">300</int>
-						<reference key="object" ref="668219766"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="89216511"/>
-						</object>
-						<reference key="parent" ref="343563030"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">301</int>
-						<reference key="object" ref="658605159"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="811252156"/>
-						</object>
-						<reference key="parent" ref="343563030"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">302</int>
-						<reference key="object" ref="293499524"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="116399245"/>
-						</object>
-						<reference key="parent" ref="343563030"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">303</int>
-						<reference key="object" ref="396267292"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="903783181"/>
-						</object>
-						<reference key="parent" ref="343563030"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">304</int>
-						<reference key="object" ref="649100559"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="64731394"/>
-						</object>
-						<reference key="parent" ref="343563030"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">305</int>
-						<reference key="object" ref="387956930"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="353713095"/>
-						</object>
-						<reference key="parent" ref="343563030"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">306</int>
-						<reference key="object" ref="706521650"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="419039838"/>
-						</object>
-						<reference key="parent" ref="343563030"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">307</int>
-						<reference key="object" ref="259224558"/>
-						<reference key="parent" ref="343563030"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">281</int>
-						<reference key="object" ref="844599924"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="556411416"/>
-						</object>
-						<reference key="parent" ref="920744728"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">282</int>
-						<reference key="object" ref="556411416"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="470745416"/>
-							<reference ref="588621662"/>
-							<reference ref="752296786"/>
-							<reference ref="702733738"/>
-							<reference ref="990578515"/>
-							<reference ref="629023827"/>
-							<reference ref="875297347"/>
-							<reference ref="716757700"/>
-							<reference ref="61970638"/>
-							<reference ref="168635732"/>
-							<reference ref="201282708"/>
-							<reference ref="520162109"/>
-							<reference ref="236533845"/>
-							<reference ref="668554983"/>
-							<reference ref="293563301"/>
-							<reference ref="835054647"/>
-						</object>
-						<reference key="parent" ref="844599924"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">284</int>
-						<reference key="object" ref="702733738"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="79651666"/>
-						</object>
-						<reference key="parent" ref="556411416"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">285</int>
-						<reference key="object" ref="470745416"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="511728981"/>
-						</object>
-						<reference key="parent" ref="556411416"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">286</int>
-						<reference key="object" ref="875297347"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="319933815"/>
-						</object>
-						<reference key="parent" ref="556411416"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">287</int>
-						<reference key="object" ref="629023827"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="813143560"/>
-						</object>
-						<reference key="parent" ref="556411416"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">288</int>
-						<reference key="object" ref="990578515"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="121487339"/>
-						</object>
-						<reference key="parent" ref="556411416"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">289</int>
-						<reference key="object" ref="588621662"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="764653811"/>
-							<reference ref="557873841"/>
-							<reference ref="971686497"/>
-						</object>
-						<reference key="parent" ref="556411416"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">292</int>
-						<reference key="object" ref="764653811"/>
-						<reference key="parent" ref="588621662"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">331</int>
-						<reference key="object" ref="333442631"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Shared User Defaults Controller</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">386</int>
-						<reference key="object" ref="646685297"/>
-						<reference key="parent" ref="1049256708"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">387</int>
-						<reference key="object" ref="89216511"/>
-						<reference key="parent" ref="668219766"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">388</int>
-						<reference key="object" ref="811252156"/>
-						<reference key="parent" ref="658605159"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">389</int>
-						<reference key="object" ref="116399245"/>
-						<reference key="parent" ref="293499524"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">390</int>
-						<reference key="object" ref="903783181"/>
-						<reference key="parent" ref="396267292"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">391</int>
-						<reference key="object" ref="64731394"/>
-						<reference key="parent" ref="649100559"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">392</int>
-						<reference key="object" ref="353713095"/>
-						<reference key="parent" ref="387956930"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">393</int>
-						<reference key="object" ref="419039838"/>
-						<reference key="parent" ref="706521650"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">394</int>
-						<reference key="object" ref="79651666"/>
-						<reference key="parent" ref="702733738"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">395</int>
-						<reference key="object" ref="511728981"/>
-						<reference key="parent" ref="470745416"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">396</int>
-						<reference key="object" ref="319933815"/>
-						<reference key="parent" ref="875297347"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">397</int>
-						<reference key="object" ref="813143560"/>
-						<reference key="parent" ref="629023827"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">398</int>
-						<reference key="object" ref="121487339"/>
-						<reference key="parent" ref="990578515"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">399</int>
-						<reference key="object" ref="557873841"/>
-						<reference key="parent" ref="588621662"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">438</int>
-						<reference key="object" ref="1072444278"/>
-						<reference key="parent" ref="183480630"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">443</int>
-						<reference key="object" ref="402399656"/>
-						<reference key="parent" ref="183480630"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">458</int>
-						<reference key="object" ref="716757700"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="121491139"/>
-						</object>
-						<reference key="parent" ref="556411416"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">459</int>
-						<reference key="object" ref="121491139"/>
-						<reference key="parent" ref="716757700"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">460</int>
-						<reference key="object" ref="450134849"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="163163325"/>
-						</object>
-						<reference key="parent" ref="343563030"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">461</int>
-						<reference key="object" ref="163163325"/>
-						<reference key="parent" ref="450134849"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">462</int>
-						<reference key="object" ref="676957937"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="94299120"/>
-						</object>
-						<reference key="parent" ref="343563030"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">463</int>
-						<reference key="object" ref="94299120"/>
-						<reference key="parent" ref="676957937"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">466</int>
-						<reference key="object" ref="913967279"/>
-						<reference key="parent" ref="343563030"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">470</int>
-						<reference key="object" ref="344543120"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="79979143"/>
-						</object>
-						<reference key="parent" ref="343563030"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">471</int>
-						<reference key="object" ref="79979143"/>
-						<reference key="parent" ref="344543120"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">472</int>
-						<reference key="object" ref="168635732"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="110272516"/>
-						</object>
-						<reference key="parent" ref="556411416"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">473</int>
-						<reference key="object" ref="201282708"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="603160133"/>
-						</object>
-						<reference key="parent" ref="556411416"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">474</int>
-						<reference key="object" ref="603160133"/>
-						<reference key="parent" ref="201282708"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">475</int>
-						<reference key="object" ref="110272516"/>
-						<reference key="parent" ref="168635732"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">291</int>
-						<reference key="object" ref="971686497"/>
-						<reference key="parent" ref="588621662"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">481</int>
-						<reference key="object" ref="520162109"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="696757669"/>
-						</object>
-						<reference key="parent" ref="556411416"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">482</int>
-						<reference key="object" ref="696757669"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="461553438"/>
-						</object>
-						<reference key="parent" ref="520162109"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">483</int>
-						<reference key="object" ref="461553438"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="723833028"/>
-							<reference ref="854160556"/>
-							<reference ref="911154180"/>
-						</object>
-						<reference key="parent" ref="696757669"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">484</int>
-						<reference key="object" ref="723833028"/>
-						<reference key="parent" ref="461553438"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">485</int>
-						<reference key="object" ref="854160556"/>
-						<reference key="parent" ref="461553438"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">486</int>
-						<reference key="object" ref="911154180"/>
-						<reference key="parent" ref="461553438"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">494</int>
-						<reference key="object" ref="79480864"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="734104716"/>
-						</object>
-						<reference key="parent" ref="920744728"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">495</int>
-						<reference key="object" ref="734104716"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="778114246"/>
-							<reference ref="990409762"/>
-							<reference ref="1008888016"/>
-							<reference ref="479912596"/>
-							<reference ref="896193182"/>
-							<reference ref="778635181"/>
-							<reference ref="205848077"/>
-							<reference ref="527416780"/>
-							<reference ref="136547617"/>
-							<reference ref="566454833"/>
-							<reference ref="639430431"/>
-							<reference ref="162798478"/>
-							<reference ref="329315625"/>
-							<reference ref="48727413"/>
-							<reference ref="370432243"/>
-							<reference ref="229798880"/>
-							<reference ref="56171983"/>
-							<reference ref="866594184"/>
-							<reference ref="1008852985"/>
-							<reference ref="434024678"/>
-							<reference ref="932528735"/>
-							<reference ref="783710730"/>
-							<reference ref="256580922"/>
-							<reference ref="213192280"/>
-						</object>
-						<reference key="parent" ref="79480864"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">501</int>
-						<reference key="object" ref="162798478"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="319545690"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">502</int>
-						<reference key="object" ref="319545690"/>
-						<reference key="parent" ref="162798478"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">509</int>
-						<reference key="object" ref="329315625"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="813582582"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">510</int>
-						<reference key="object" ref="813582582"/>
-						<reference key="parent" ref="329315625"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">511</int>
-						<reference key="object" ref="48727413"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="966132901"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">512</int>
-						<reference key="object" ref="966132901"/>
-						<reference key="parent" ref="48727413"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">513</int>
-						<reference key="object" ref="370432243"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="648858317"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">514</int>
-						<reference key="object" ref="648858317"/>
-						<reference key="parent" ref="370432243"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">515</int>
-						<reference key="object" ref="229798880"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="862308995"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">516</int>
-						<reference key="object" ref="862308995"/>
-						<reference key="parent" ref="229798880"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">517</int>
-						<reference key="object" ref="56171983"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="262821321"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">518</int>
-						<reference key="object" ref="262821321"/>
-						<reference key="parent" ref="56171983"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">519</int>
-						<reference key="object" ref="866594184"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="878656198"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">520</int>
-						<reference key="object" ref="878656198"/>
-						<reference key="parent" ref="866594184"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">521</int>
-						<reference key="object" ref="434024678"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="918479979"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">522</int>
-						<reference key="object" ref="918479979"/>
-						<reference key="parent" ref="434024678"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">523</int>
-						<reference key="object" ref="932528735"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="55673680"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">524</int>
-						<reference key="object" ref="55673680"/>
-						<reference key="parent" ref="932528735"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">525</int>
-						<reference key="object" ref="778635181"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="795322137"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">526</int>
-						<reference key="object" ref="795322137"/>
-						<reference key="parent" ref="778635181"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">527</int>
-						<reference key="object" ref="205848077"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="853626170"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">528</int>
-						<reference key="object" ref="853626170"/>
-						<reference key="parent" ref="205848077"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">529</int>
-						<reference key="object" ref="527416780"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="1064523668"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">530</int>
-						<reference key="object" ref="1064523668"/>
-						<reference key="parent" ref="527416780"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">531</int>
-						<reference key="object" ref="136547617"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="201490911"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">532</int>
-						<reference key="object" ref="201490911"/>
-						<reference key="parent" ref="136547617"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">533</int>
-						<reference key="object" ref="566454833"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="676075530"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">534</int>
-						<reference key="object" ref="676075530"/>
-						<reference key="parent" ref="566454833"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">541</int>
-						<reference key="object" ref="783710730"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="424806521"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">542</int>
-						<reference key="object" ref="424806521"/>
-						<reference key="parent" ref="783710730"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">543</int>
-						<reference key="object" ref="639430431"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="60275823"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">544</int>
-						<reference key="object" ref="60275823"/>
-						<reference key="parent" ref="639430431"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">545</int>
-						<reference key="object" ref="990409762"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="380966888"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">546</int>
-						<reference key="object" ref="380966888"/>
-						<reference key="parent" ref="990409762"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">547</int>
-						<reference key="object" ref="479912596"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="630653599"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">548</int>
-						<reference key="object" ref="630653599"/>
-						<reference key="parent" ref="479912596"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">549</int>
-						<reference key="object" ref="896193182"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="587691603"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">550</int>
-						<reference key="object" ref="587691603"/>
-						<reference key="parent" ref="896193182"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">551</int>
-						<reference key="object" ref="1008888016"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="517511508"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">552</int>
-						<reference key="object" ref="517511508"/>
-						<reference key="parent" ref="1008888016"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">553</int>
-						<reference key="object" ref="1008852985"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="123364609"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">554</int>
-						<reference key="object" ref="123364609"/>
-						<reference key="parent" ref="1008852985"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">555</int>
-						<reference key="object" ref="752296786"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="260441203"/>
-						</object>
-						<reference key="parent" ref="556411416"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">556</int>
-						<reference key="object" ref="260441203"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="809213331"/>
-						</object>
-						<reference key="parent" ref="752296786"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">557</int>
-						<reference key="object" ref="809213331"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="139505003"/>
-							<reference ref="297660508"/>
-							<reference ref="83198116"/>
-							<reference ref="596086471"/>
-							<reference ref="654793636"/>
-							<reference ref="219246953"/>
-						</object>
-						<reference key="parent" ref="260441203"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">558</int>
-						<reference key="object" ref="139505003"/>
-						<reference key="parent" ref="809213331"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">559</int>
-						<reference key="object" ref="297660508"/>
-						<reference key="parent" ref="809213331"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">560</int>
-						<reference key="object" ref="83198116"/>
-						<reference key="parent" ref="809213331"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">561</int>
-						<reference key="object" ref="596086471"/>
-						<reference key="parent" ref="809213331"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">562</int>
-						<reference key="object" ref="654793636"/>
-						<reference key="parent" ref="809213331"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">673</int>
-						<reference key="object" ref="61970638"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="411558436"/>
-						</object>
-						<reference key="parent" ref="556411416"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">674</int>
-						<reference key="object" ref="411558436"/>
-						<reference key="parent" ref="61970638"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">675</int>
-						<reference key="object" ref="236533845"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="1036969072"/>
-						</object>
-						<reference key="parent" ref="556411416"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">676</int>
-						<reference key="object" ref="1036969072"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="911772948"/>
-						</object>
-						<reference key="parent" ref="236533845"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">677</int>
-						<reference key="object" ref="911772948"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="239601200"/>
-							<reference ref="25022990"/>
-						</object>
-						<reference key="parent" ref="1036969072"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">679</int>
-						<reference key="object" ref="239601200"/>
-						<reference key="parent" ref="911772948"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">680</int>
-						<reference key="object" ref="25022990"/>
-						<reference key="parent" ref="911772948"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">689</int>
-						<reference key="object" ref="850400115"/>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">694</int>
-						<reference key="object" ref="200766654"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="725427137"/>
-						</object>
-						<reference key="parent" ref="920744728"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">695</int>
-						<reference key="object" ref="725427137"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="53152157"/>
-						</object>
-						<reference key="parent" ref="200766654"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">696</int>
-						<reference key="object" ref="53152157"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="297985295"/>
-							<reference ref="950456908"/>
-							<reference ref="788144279"/>
-							<reference ref="839026685"/>
-						</object>
-						<reference key="parent" ref="725427137"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">697</int>
-						<reference key="object" ref="297985295"/>
-						<reference key="parent" ref="53152157"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">698</int>
-						<reference key="object" ref="950456908"/>
-						<reference key="parent" ref="53152157"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">699</int>
-						<reference key="object" ref="788144279"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="650465578"/>
-							<reference ref="400622282"/>
-							<reference ref="128275113"/>
-						</object>
-						<reference key="parent" ref="53152157"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">700</int>
-						<reference key="object" ref="839026685"/>
-						<reference key="parent" ref="53152157"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">701</int>
-						<reference key="object" ref="650465578"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="952921586"/>
-						</object>
-						<reference key="parent" ref="788144279"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">702</int>
-						<reference key="object" ref="400622282"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="236435869"/>
-						</object>
-						<reference key="parent" ref="788144279"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">703</int>
-						<reference key="object" ref="236435869"/>
-						<reference key="parent" ref="400622282"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">705</int>
-						<reference key="object" ref="128275113"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="615487221"/>
-						</object>
-						<reference key="parent" ref="788144279"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">707</int>
-						<reference key="object" ref="952921586"/>
-						<reference key="parent" ref="650465578"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">706</int>
-						<reference key="object" ref="615487221"/>
-						<reference key="parent" ref="128275113"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">709</int>
-						<reference key="object" ref="387553423"/>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">721</int>
-						<reference key="object" ref="840782193"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="680292339"/>
-						</object>
-						<reference key="parent" ref="343563030"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">722</int>
-						<reference key="object" ref="680292339"/>
-						<reference key="parent" ref="840782193"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">723</int>
-						<reference key="object" ref="921987807"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="565681738"/>
-						</object>
-						<reference key="parent" ref="343563030"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">724</int>
-						<reference key="object" ref="565681738"/>
-						<reference key="parent" ref="921987807"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">727</int>
-						<reference key="object" ref="668554983"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="453322497"/>
-						</object>
-						<reference key="parent" ref="556411416"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">728</int>
-						<reference key="object" ref="453322497"/>
-						<reference key="parent" ref="668554983"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">731</int>
-						<reference key="object" ref="718470466"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="404366215"/>
-						</object>
-						<reference key="parent" ref="920744728"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">732</int>
-						<reference key="object" ref="404366215"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="426394681"/>
-							<reference ref="6795274"/>
-							<reference ref="572714115"/>
-						</object>
-						<reference key="parent" ref="718470466"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">733</int>
-						<reference key="object" ref="426394681"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="999022373"/>
-						</object>
-						<reference key="parent" ref="404366215"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">734</int>
-						<reference key="object" ref="6795274"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="1033602394"/>
-						</object>
-						<reference key="parent" ref="404366215"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">735</int>
-						<reference key="object" ref="1033602394"/>
-						<reference key="parent" ref="6795274"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">736</int>
-						<reference key="object" ref="999022373"/>
-						<reference key="parent" ref="426394681"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">745</int>
-						<reference key="object" ref="572714115"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="958503593"/>
-						</object>
-						<reference key="parent" ref="404366215"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">746</int>
-						<reference key="object" ref="958503593"/>
-						<reference key="parent" ref="572714115"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">747</int>
-						<reference key="object" ref="778114246"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="903629445"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">748</int>
-						<reference key="object" ref="903629445"/>
-						<reference key="parent" ref="778114246"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">751</int>
-						<reference key="object" ref="256580922"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="876130661"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">752</int>
-						<reference key="object" ref="876130661"/>
-						<reference key="parent" ref="256580922"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">756</int>
-						<reference key="object" ref="213192280"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="217309235"/>
-						</object>
-						<reference key="parent" ref="734104716"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">757</int>
-						<reference key="object" ref="217309235"/>
-						<reference key="parent" ref="213192280"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">762</int>
-						<reference key="object" ref="293563301"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="405082331"/>
-						</object>
-						<reference key="parent" ref="556411416"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">763</int>
-						<reference key="object" ref="405082331"/>
-						<reference key="parent" ref="293563301"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">764</int>
-						<reference key="object" ref="835054647"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="539388088"/>
-						</object>
-						<reference key="parent" ref="556411416"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">765</int>
-						<reference key="object" ref="539388088"/>
-						<reference key="parent" ref="835054647"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">769</int>
-						<reference key="object" ref="219246953"/>
-						<reference key="parent" ref="809213331"/>
-					</object>
-				</object>
-			</object>
-			<object class="NSMutableDictionary" key="flattenedProperties">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<object class="NSArray" key="dict.sortedKeys">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-					<string>-1.IBPluginDependency</string>
-					<string>-2.IBPluginDependency</string>
-					<string>-3.IBPluginDependency</string>
-					<string>252.IBPluginDependency</string>
-					<string>268.IBPluginDependency</string>
-					<string>269.IBPluginDependency</string>
-					<string>273.IBPluginDependency</string>
-					<string>277.IBPluginDependency</string>
-					<string>277.IBWindowTemplateEditedContentRect</string>
-					<string>278.IBPluginDependency</string>
-					<string>279.IBPluginDependency</string>
-					<string>280.IBPluginDependency</string>
-					<string>281.IBPluginDependency</string>
-					<string>282.IBPluginDependency</string>
-					<string>284.IBPluginDependency</string>
-					<string>285.IBPluginDependency</string>
-					<string>286.IBPluginDependency</string>
-					<string>287.IBPluginDependency</string>
-					<string>288.IBPluginDependency</string>
-					<string>289.IBAttributePlaceholdersKey</string>
-					<string>289.IBPluginDependency</string>
-					<string>291.IBPluginDependency</string>
-					<string>292.IBPluginDependency</string>
-					<string>298.IBPluginDependency</string>
-					<string>299.IBPluginDependency</string>
-					<string>300.IBPluginDependency</string>
-					<string>301.IBPluginDependency</string>
-					<string>302.IBPluginDependency</string>
-					<string>303.IBPluginDependency</string>
-					<string>304.IBPluginDependency</string>
-					<string>305.IBPluginDependency</string>
-					<string>306.IBPluginDependency</string>
-					<string>307.IBPluginDependency</string>
-					<string>331.IBPluginDependency</string>
-					<string>386.IBPluginDependency</string>
-					<string>387.IBPluginDependency</string>
-					<string>388.IBPluginDependency</string>
-					<string>389.IBPluginDependency</string>
-					<string>390.IBPluginDependency</string>
-					<string>391.IBPluginDependency</string>
-					<string>392.IBPluginDependency</string>
-					<string>393.IBPluginDependency</string>
-					<string>394.IBPluginDependency</string>
-					<string>395.IBPluginDependency</string>
-					<string>396.IBPluginDependency</string>
-					<string>397.IBPluginDependency</string>
-					<string>398.IBPluginDependency</string>
-					<string>399.IBPluginDependency</string>
-					<string>438.IBPluginDependency</string>
-					<string>443.IBPluginDependency</string>
-					<string>458.IBPluginDependency</string>
-					<string>459.IBPluginDependency</string>
-					<string>460.IBPluginDependency</string>
-					<string>461.IBPluginDependency</string>
-					<string>462.IBPluginDependency</string>
-					<string>463.IBPluginDependency</string>
-					<string>466.IBPluginDependency</string>
-					<string>470.IBPluginDependency</string>
-					<string>471.IBPluginDependency</string>
-					<string>472.IBPluginDependency</string>
-					<string>473.IBPluginDependency</string>
-					<string>474.IBPluginDependency</string>
-					<string>475.IBPluginDependency</string>
-					<string>481.IBPluginDependency</string>
-					<string>482.IBPluginDependency</string>
-					<string>483.IBPluginDependency</string>
-					<string>484.IBPluginDependency</string>
-					<string>485.IBPluginDependency</string>
-					<string>486.IBPluginDependency</string>
-					<string>494.IBPluginDependency</string>
-					<string>495.IBPluginDependency</string>
-					<string>501.IBPluginDependency</string>
-					<string>502.IBPluginDependency</string>
-					<string>509.IBPluginDependency</string>
-					<string>510.IBPluginDependency</string>
-					<string>511.IBPluginDependency</string>
-					<string>512.IBPluginDependency</string>
-					<string>513.IBPluginDependency</string>
-					<string>514.IBPluginDependency</string>
-					<string>515.IBPluginDependency</string>
-					<string>516.IBPluginDependency</string>
-					<string>517.IBPluginDependency</string>
-					<string>518.IBPluginDependency</string>
-					<string>519.IBPluginDependency</string>
-					<string>520.IBPluginDependency</string>
-					<string>521.IBPluginDependency</string>
-					<string>522.IBPluginDependency</string>
-					<string>523.IBPluginDependency</string>
-					<string>524.IBPluginDependency</string>
-					<string>525.IBPluginDependency</string>
-					<string>526.IBPluginDependency</string>
-					<string>527.IBPluginDependency</string>
-					<string>528.IBPluginDependency</string>
-					<string>529.IBPluginDependency</string>
-					<string>530.IBPluginDependency</string>
-					<string>531.IBPluginDependency</string>
-					<string>532.IBPluginDependency</string>
-					<string>533.IBPluginDependency</string>
-					<string>534.IBPluginDependency</string>
-					<string>541.IBPluginDependency</string>
-					<string>542.IBPluginDependency</string>
-					<string>543.IBPluginDependency</string>
-					<string>544.IBPluginDependency</string>
-					<string>545.IBPluginDependency</string>
-					<string>546.IBPluginDependency</string>
-					<string>547.IBPluginDependency</string>
-					<string>548.IBPluginDependency</string>
-					<string>549.IBPluginDependency</string>
-					<string>550.IBPluginDependency</string>
-					<string>551.IBPluginDependency</string>
-					<string>552.IBPluginDependency</string>
-					<string>553.IBPluginDependency</string>
-					<string>554.IBPluginDependency</string>
-					<string>555.IBPluginDependency</string>
-					<string>556.IBPluginDependency</string>
-					<string>557.IBPluginDependency</string>
-					<string>558.IBPluginDependency</string>
-					<string>559.IBPluginDependency</string>
-					<string>560.IBPluginDependency</string>
-					<string>561.IBPluginDependency</string>
-					<string>562.IBPluginDependency</string>
-					<string>673.IBPluginDependency</string>
-					<string>674.IBPluginDependency</string>
-					<string>675.IBPluginDependency</string>
-					<string>676.IBPluginDependency</string>
-					<string>677.IBPluginDependency</string>
-					<string>679.IBPluginDependency</string>
-					<string>680.IBPluginDependency</string>
-					<string>689.IBPluginDependency</string>
-					<string>694.IBPluginDependency</string>
-					<string>695.IBPluginDependency</string>
-					<string>696.IBPluginDependency</string>
-					<string>697.IBPluginDependency</string>
-					<string>698.IBPluginDependency</string>
-					<string>699.IBPluginDependency</string>
-					<string>700.IBPluginDependency</string>
-					<string>701.IBPluginDependency</string>
-					<string>702.IBPluginDependency</string>
-					<string>703.IBPluginDependency</string>
-					<string>705.IBPluginDependency</string>
-					<string>706.IBPluginDependency</string>
-					<string>707.IBPluginDependency</string>
-					<string>709.IBPluginDependency</string>
-					<string>721.IBPluginDependency</string>
-					<string>722.IBPluginDependency</string>
-					<string>723.IBPluginDependency</string>
-					<string>724.IBPluginDependency</string>
-					<string>727.IBPluginDependency</string>
-					<string>728.IBPluginDependency</string>
-					<string>731.IBPluginDependency</string>
-					<string>732.IBPluginDependency</string>
-					<string>733.IBPluginDependency</string>
-					<string>734.IBPluginDependency</string>
-					<string>735.IBPluginDependency</string>
-					<string>736.IBPluginDependency</string>
-					<string>745.IBPluginDependency</string>
-					<string>746.IBPluginDependency</string>
-					<string>747.IBPluginDependency</string>
-					<string>748.IBPluginDependency</string>
-					<string>751.IBPluginDependency</string>
-					<string>752.IBPluginDependency</string>
-					<string>756.IBPluginDependency</string>
-					<string>757.IBPluginDependency</string>
-					<string>762.IBPluginDependency</string>
-					<string>763.IBPluginDependency</string>
-					<string>764.IBPluginDependency</string>
-					<string>765.IBPluginDependency</string>
-					<string>769.IBPluginDependency</string>
-				</object>
-				<object class="NSMutableArray" key="dict.values">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>{{825, 682}, {432, 419}}</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<object class="NSMutableDictionary">
-						<string key="NS.key.0">ToolTip</string>
-						<object class="IBToolTipAttribute" key="NS.object.0">
-							<string key="name">ToolTip</string>
-							<reference key="object" ref="588621662"/>
-							<string key="toolTip">This setting would only affect the next activated input session!</string>
-						</object>
-					</object>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-				</object>
-			</object>
-			<object class="NSMutableDictionary" key="unlocalizedProperties">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<reference key="dict.sortedKeys" ref="0"/>
-				<reference key="dict.values" ref="0"/>
-			</object>
-			<nil key="activeLocalization"/>
-			<object class="NSMutableDictionary" key="localizations">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<reference key="dict.sortedKeys" ref="0"/>
-				<reference key="dict.values" ref="0"/>
-			</object>
-			<nil key="sourceID"/>
-			<int key="maxID">769</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<object class="IBPartialClassDescription">
-					<string key="className">CandidateWindow</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/CandidateWindow.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">SUUpdater</string>
-					<string key="superclassName">NSObject</string>
-					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">checkForUpdates:</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">checkForUpdates:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">checkForUpdates:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="NSMutableDictionary" key="outlets">
-						<string key="NS.key.0">delegate</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<string key="NS.key.0">delegate</string>
-						<object class="IBToOneOutletInfo" key="NS.object.0">
-							<string key="name">delegate</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/SUUpdater.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">SunPinyinApplicationDelegate</string>
-					<string key="superclassName">NSObject</string>
-					<object class="NSMutableDictionary" key="actions">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>showFontPanel:</string>
-							<string>showPrefPanel:</string>
-							<string>toggleChinesePuncts:</string>
-							<string>toggleFullSymbols:</string>
-						</object>
-						<object class="NSMutableArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-						</object>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>showFontPanel:</string>
-							<string>showPrefPanel:</string>
-							<string>toggleChinesePuncts:</string>
-							<string>toggleFullSymbols:</string>
-						</object>
-						<object class="NSMutableArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<object class="IBActionInfo">
-								<string key="name">showFontPanel:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">showPrefPanel:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">toggleChinesePuncts:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">toggleFullSymbols:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-						</object>
-					</object>
-					<object class="NSMutableDictionary" key="outlets">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>_candiWin</string>
-							<string>_ftTxtField</string>
-							<string>_menu</string>
-							<string>_prefPanel</string>
-						</object>
-						<object class="NSMutableArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>CandidateWindow</string>
-							<string>NSTextField</string>
-							<string>NSMenu</string>
-							<string>NSPanel</string>
-						</object>
-					</object>
-					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>_candiWin</string>
-							<string>_ftTxtField</string>
-							<string>_menu</string>
-							<string>_prefPanel</string>
-						</object>
-						<object class="NSMutableArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<object class="IBToOneOutletInfo">
-								<string key="name">_candiWin</string>
-								<string key="candidateClassName">CandidateWindow</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">_ftTxtField</string>
-								<string key="candidateClassName">NSTextField</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">_menu</string>
-								<string key="candidateClassName">NSMenu</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">_prefPanel</string>
-								<string key="candidateClassName">NSPanel</string>
-							</object>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/SunPinyinApplicationDelegate.h</string>
-					</object>
-				</object>
-			</object>
-		</object>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
-			<integer value="1050" key="NS.object.0"/>
-		</object>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencyDefaults">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
-			<integer value="1050" key="NS.object.0"/>
-		</object>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>
-			<integer value="3000" key="NS.object.0"/>
-		</object>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<object class="NSMutableDictionary" key="IBDocument.LastKnownImageSizes">
-			<bool key="EncodedWithXMLCoder">YES</bool>
-			<object class="NSArray" key="dict.sortedKeys">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<string>NSMenuCheckmark</string>
-				<string>NSMenuMixedState</string>
-				<string>NSSwitch</string>
-			</object>
-			<object class="NSMutableArray" key="dict.values">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<string>{9, 8}</string>
-				<string>{7, 2}</string>
-				<string>{15, 15}</string>
-			</object>
-		</object>
-	</data>
-</archive>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15705" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <deployment version="1090" identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
+            <connections>
+                <outlet property="delegate" destination="252" id="253"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application"/>
+        <customObject id="252" userLabel="SunPinyinApplicationDelegate" customClass="SunPinyinApplicationDelegate">
+            <connections>
+                <outlet property="_candiWin" destination="273" id="275"/>
+                <outlet property="_ftTxtField" destination="304" id="437"/>
+                <outlet property="_menu" destination="268" id="271"/>
+                <outlet property="_prefPanel" destination="277" id="366"/>
+            </connections>
+        </customObject>
+        <menu title="Menu" id="268" userLabel="Menu (Menu)">
+            <items>
+                <menuItem title="Chinese Puncts" state="on" keyEquivalent="." id="438">
+                    <modifierMask key="keyEquivalentModifierMask" control="YES"/>
+                    <connections>
+                        <action selector="toggleChinesePuncts:" target="252" id="442"/>
+                        <binding destination="331" name="value" keyPath="values.inputChinesePuncts" id="441"/>
+                    </connections>
+                </menuItem>
+                <menuItem title="Full-Width Symbol" tag="1" keyEquivalent=" " id="443">
+                    <modifierMask key="keyEquivalentModifierMask" option="YES"/>
+                    <connections>
+                        <action selector="toggleFullSymbols:" target="252" id="444"/>
+                        <binding destination="331" name="value" keyPath="values.inputFullSymbols" id="446"/>
+                    </connections>
+                </menuItem>
+                <menuItem title="Preferences..." tag="2" id="269">
+                    <connections>
+                        <action selector="showPrefPanel:" target="252" id="383"/>
+                    </connections>
+                </menuItem>
+            </items>
+            <point key="canvasLocation" x="140" y="152"/>
+        </menu>
+        <customObject id="273" userLabel="CandidateWindow" customClass="CandidateWindow"/>
+        <window title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="277" userLabel="PrefPanel (Panel)" customClass="NSPanel">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" utility="YES" nonactivatingPanel="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="330" y="439" width="432" height="419"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1057"/>
+            <view key="contentView" id="278">
+                <rect key="frame" x="0.0" y="0.0" width="432" height="419"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <tabView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="279">
+                        <rect key="frame" x="13" y="10" width="406" height="403"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <font key="font" metaFont="system"/>
+                        <tabViewItems>
+                            <tabViewItem label="General" identifier="1" id="281">
+                                <view key="view" id="282">
+                                    <rect key="frame" x="10" y="33" width="386" height="357"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="285">
+                                            <rect key="frame" x="23" y="321" width="145" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Pinyin Mode:" id="395">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <matrix toolTip="This setting would only affect the next activated input session!" verticalHuggingPriority="750" fixedFrame="YES" allowsEmptySelection="NO" autosizesCells="NO" translatesAutoresizingMaskIntoConstraints="NO" id="289">
+                                            <rect key="frame" x="171" y="296" width="163" height="42"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            <size key="cellSize" width="163" height="20"/>
+                                            <size key="intercellSpacing" width="4" height="2"/>
+                                            <buttonCell key="prototype" type="radio" title="Radio" imagePosition="leading" alignment="left" inset="2" id="399">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <cells>
+                                                <column>
+                                                    <buttonCell type="radio" title="Quan Pin" imagePosition="leading" alignment="left" state="on" inset="2" id="292">
+                                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                        <font key="font" metaFont="system"/>
+                                                    </buttonCell>
+                                                    <buttonCell type="radio" title="Shuang Pin" imagePosition="leading" alignment="left" tag="1" inset="2" id="291">
+                                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                        <font key="font" metaFont="system"/>
+                                                    </buttonCell>
+                                                </column>
+                                            </cells>
+                                            <connections>
+                                                <binding destination="331" name="selectedTag" keyPath="values.pinyinMode" id="564"/>
+                                            </connections>
+                                        </matrix>
+                                        <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="284">
+                                            <rect key="frame" x="35" y="163" width="133" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Pagings:" id="394">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="762">
+                                            <rect key="frame" x="36" y="76" width="133" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Miscs:" id="763">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="288">
+                                            <rect key="frame" x="172" y="162" width="187" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="Use -/= to page up/down" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="398">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="value" keyPath="values.pagingByMinusAndEqual" id="418"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="287">
+                                            <rect key="frame" x="172" y="142" width="187" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="Use [/] to page up/down" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="397">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="value" keyPath="values.pagingByBrackets" id="409"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="286">
+                                            <rect key="frame" x="172" y="122" width="187" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="Use ,/. to page up/down" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="396">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="value" keyPath="values.pagingByCommaAndDot" id="411"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="727">
+                                            <rect key="frame" x="172" y="102" width="187" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="Use ↑/↓ to page up/down" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="728">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="value" keyPath="values.pagingByArrowUpAndDown" id="730"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="458">
+                                            <rect key="frame" x="14" y="258" width="155" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Switch English/Chinese:" id="459">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="673">
+                                            <rect key="frame" x="-28" y="230" width="197" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="On Switching:" id="674">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="472">
+                                            <rect key="frame" x="172" y="188" width="187" height="26"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="Force to use US layout" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="475">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="value" keyPath="values.usingUSKbLayout" id="480"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="764">
+                                            <rect key="frame" x="172" y="71" width="236" height="26"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="Use ⌫ to cancel selections" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="765">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="value" keyPath="values.cancelSelectionOnBackspace" id="768"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="473">
+                                            <rect key="frame" x="55" y="193" width="114" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Keyboard Layout:" id="474">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <popUpButton verticalHuggingPriority="750" fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="481">
+                                            <rect key="frame" x="171" y="252" width="189" height="26"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <popUpButtonCell key="cell" type="push" title="None" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="484" id="482">
+                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <menu key="menu" title="OtherViews" id="483">
+                                                    <items>
+                                                        <menuItem title="None" state="on" id="484"/>
+                                                        <menuItem title="With Caps Lock (⇪)" id="485"/>
+                                                        <menuItem title="With Shift (⇧)" id="486"/>
+                                                    </items>
+                                                </menu>
+                                                <connections>
+                                                    <binding destination="331" name="selectedIndex" keyPath="values.switchingPolicy" id="490"/>
+                                                </connections>
+                                            </popUpButtonCell>
+                                        </popUpButton>
+                                        <popUpButton verticalHuggingPriority="750" fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="675">
+                                            <rect key="frame" x="171" y="224" width="189" height="26"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <popUpButtonCell key="cell" type="push" title="Commit Pinyin String" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="680" id="676">
+                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <menu key="menu" title="OtherViews" id="677">
+                                                    <items>
+                                                        <menuItem title="Commit Pinyin String" state="on" id="680"/>
+                                                        <menuItem title="Commit Chinese Words" id="679"/>
+                                                    </items>
+                                                </menu>
+                                                <connections>
+                                                    <binding destination="331" name="selectedIndex" keyPath="values.commitPolicy" id="682"/>
+                                                </connections>
+                                            </popUpButtonCell>
+                                            <connections>
+                                                <binding destination="331" name="enabled" keyPath="values.switchingPolicy" id="688"/>
+                                            </connections>
+                                        </popUpButton>
+                                        <popUpButton verticalHuggingPriority="750" fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="555">
+                                            <rect key="frame" x="260" y="292" width="100" height="26"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <popUpButtonCell key="cell" type="push" title="MS2003" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="558" id="556">
+                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <menu key="menu" title="OtherViews" id="557">
+                                                    <items>
+                                                        <menuItem title="MS2003" state="on" id="558"/>
+                                                        <menuItem title="ABC" id="559"/>
+                                                        <menuItem title="ZiRanMa" id="560"/>
+                                                        <menuItem title="Pinyin++" id="561"/>
+                                                        <menuItem title="ZiGuang" id="562"/>
+                                                        <menuItem title="XiaoHe" id="769">
+                                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                                        </menuItem>
+                                                    </items>
+                                                </menu>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.pinyinMode" id="672"/>
+                                                    <binding destination="331" name="selectedIndex" keyPath="values.Shuangpin.Scheme" id="616"/>
+                                                </connections>
+                                            </popUpButtonCell>
+                                        </popUpButton>
+                                    </subviews>
+                                </view>
+                            </tabViewItem>
+                            <tabViewItem label="Pinyin" identifier="Item 2" id="494">
+                                <view key="view" id="495">
+                                    <rect key="frame" x="10" y="33" width="386" height="357"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="501">
+                                            <rect key="frame" x="35" y="226" width="63" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="z - zh" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="502">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.Quanpin.Fuzzy.Enabled" id="640"/>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.Fuzzy.ZhiZi" id="596"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="509">
+                                            <rect key="frame" x="35" y="206" width="63" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="c - ch" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="510">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.Quanpin.Fuzzy.Enabled" id="668"/>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.Fuzzy.ChiCi" id="597"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="511">
+                                            <rect key="frame" x="35" y="186" width="63" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="s - sh" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="512">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.Quanpin.Fuzzy.Enabled" id="643"/>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.Fuzzy.ShiSi" id="598"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="513">
+                                            <rect key="frame" x="35" y="166" width="77" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="an - ang" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="514">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.Quanpin.Fuzzy.Enabled" id="644"/>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.Fuzzy.AnAng" id="599"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="515">
+                                            <rect key="frame" x="35" y="146" width="78" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="on - ong" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="516">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.Quanpin.Fuzzy.Enabled" id="645"/>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.Fuzzy.OnOng" id="600"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="517">
+                                            <rect key="frame" x="35" y="126" width="78" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="en - eng" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="518">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.Quanpin.Fuzzy.Enabled" id="646"/>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.Fuzzy.EnEng" id="601"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="519">
+                                            <rect key="frame" x="35" y="106" width="78" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="in - ing" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="520">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.Quanpin.Fuzzy.Enabled" id="647"/>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.Fuzzy.InIng" id="602"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="545">
+                                            <rect key="frame" x="35" y="54" width="88" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="gn -&gt; ng" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="546">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.Quanpin.AutoCorrecting.Enabled" id="660"/>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.AutoCorrecting.GnNg" id="744"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="551">
+                                            <rect key="frame" x="182" y="54" width="88" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="uen -&gt; un" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="552">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.Quanpin.AutoCorrecting.Enabled" id="662"/>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.AutoCorrecting.UenUn" id="614"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="553">
+                                            <rect key="frame" x="182" y="34" width="88" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="iou -&gt; iu" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="554">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.Quanpin.AutoCorrecting.Enabled" id="665"/>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.AutoCorrecting.IouIu" id="615"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="547">
+                                            <rect key="frame" x="35" y="34" width="92" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="img -&gt; ing" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="548">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.Quanpin.AutoCorrecting.Enabled" id="664"/>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.AutoCorrecting.ImgIng" id="612"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="549">
+                                            <rect key="frame" x="35" y="14" width="92" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="uei -&gt; ui" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="550">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.Quanpin.AutoCorrecting.Enabled" id="667"/>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.AutoCorrecting.UeiUi" id="613"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="521">
+                                            <rect key="frame" x="182" y="226" width="86" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="eng - ong" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="522">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.Quanpin.Fuzzy.Enabled" id="648"/>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.Fuzzy.EngOng" id="603"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="523">
+                                            <rect key="frame" x="182" y="206" width="86" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="ian - iang" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="524">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.Quanpin.Fuzzy.Enabled" id="650"/>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.Fuzzy.IanIang" id="604"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="525">
+                                            <rect key="frame" x="182" y="186" width="93" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="uan - uang" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="526">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.Quanpin.Fuzzy.Enabled" id="652"/>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.Fuzzy.UanUang" id="605"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="527">
+                                            <rect key="frame" x="182" y="166" width="93" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="l - n" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="528">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.Quanpin.Fuzzy.Enabled" id="653"/>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.Fuzzy.NeLe" id="606"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="529">
+                                            <rect key="frame" x="182" y="146" width="93" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="f - h" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="530">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.Quanpin.Fuzzy.Enabled" id="655"/>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.Fuzzy.FoHe" id="607"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="531">
+                                            <rect key="frame" x="182" y="126" width="93" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="r - l" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="532">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.Quanpin.Fuzzy.Enabled" id="656"/>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.Fuzzy.LeRi" id="608"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="533">
+                                            <rect key="frame" x="182" y="106" width="93" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="k - g" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="534">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.Quanpin.Fuzzy.Enabled" id="659"/>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.Fuzzy.KeGe" id="609"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="541">
+                                            <rect key="frame" x="15" y="252" width="101" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="Fuzzy Pinyin" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="542">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.Fuzzy.Enabled" id="595"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="747">
+                                            <rect key="frame" x="15" y="329" width="348" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="Smarter Segmentation (only applicable for QuanPin)" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="748">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.FuzzySegs.Enabled" id="750"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="756">
+                                            <rect key="frame" x="35" y="306" width="348" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="Enable Inner Fuzzies" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="757">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="enabled" keyPath="values.Quanpin.FuzzySegs.Enabled" id="761"/>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.FuzzySegs.InnerFuzzy.Enabled" id="759"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="751">
+                                            <rect key="frame" x="15" y="280" width="348" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="Simpler Initials (z/c/s -&gt; zh/ch/sh)" bezelStyle="regularSquare" imagePosition="leading" alignment="left" state="on" inset="2" id="752">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.Fuzzy.SimplerInitials" id="755"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="543">
+                                            <rect key="frame" x="15" y="77" width="289" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="Auto Correct (only applicable for QuanPin)" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="544">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <binding destination="331" name="value" keyPath="values.Quanpin.AutoCorrecting.Enabled" id="610"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
+                                    </subviews>
+                                </view>
+                            </tabViewItem>
+                            <tabViewItem label="Candidates" identifier="2" id="280">
+                                <view key="view" ambiguous="YES" id="298">
+                                    <rect key="frame" x="10" y="33" width="386" height="357"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="305">
+                                            <rect key="frame" x="110" y="253" width="38" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Font:" id="392">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <button verticalHuggingPriority="750" fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="303">
+                                            <rect key="frame" x="284" y="240" width="94" height="32"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="push" title="Select ..." bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="390">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="showFontPanel:" target="252" id="350"/>
+                                            </connections>
+                                        </button>
+                                        <colorWell fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="307">
+                                            <rect key="frame" x="161" y="212" width="92" height="23"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <color key="color" red="1" green="0.5" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <connections>
+                                                <binding destination="331" name="value" keyPath="values.bgColor" id="432">
+                                                    <dictionary key="options">
+                                                        <string key="NSValueTransformerName">NSUnarchiveFromData</string>
+                                                    </dictionary>
+                                                </binding>
+                                            </connections>
+                                        </colorWell>
+                                        <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="306">
+                                            <rect key="frame" x="14" y="215" width="134" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Background:" id="393">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="470">
+                                            <rect key="frame" x="14" y="177" width="134" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Highlighting:" id="471">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="301">
+                                            <rect key="frame" x="54" y="142" width="94" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Transparency:" id="388">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="721">
+                                            <rect key="frame" x="54" y="111" width="94" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Radius:" id="722">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <slider verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="302">
+                                            <rect key="frame" x="159" y="139" width="96" height="21"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <sliderCell key="cell" state="on" alignment="left" maxValue="100" doubleValue="75" tickMarkPosition="above" sliderType="linear" id="389">
+                                                <font key="font" size="12" name="Helvetica"/>
+                                                <connections>
+                                                    <binding destination="331" name="value" keyPath="values.alpha" id="416"/>
+                                                </connections>
+                                            </sliderCell>
+                                        </slider>
+                                        <slider verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="723">
+                                            <rect key="frame" x="159" y="108" width="96" height="21"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <sliderCell key="cell" state="on" alignment="left" maxValue="10" doubleValue="5" tickMarkPosition="above" sliderType="linear" id="724">
+                                                <font key="font" size="12" name="Helvetica"/>
+                                                <connections>
+                                                    <binding destination="331" name="value" keyPath="values.radius" id="726"/>
+                                                </connections>
+                                            </sliderCell>
+                                        </slider>
+                                        <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="300">
+                                            <rect key="frame" x="14" y="289" width="134" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Total Candidates:" id="387">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <comboBox verticalHuggingPriority="750" fixedFrame="YES" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="299">
+                                            <rect key="frame" x="161" y="282" width="95" height="26"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" title="9" drawsBackground="YES" completes="NO" numberOfVisibleItems="6" id="386">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                <objectValues>
+                                                    <string>4</string>
+                                                    <string>5</string>
+                                                    <string>6</string>
+                                                    <string>7</string>
+                                                    <string>8</string>
+                                                    <string>9</string>
+                                                </objectValues>
+                                            </comboBoxCell>
+                                            <connections>
+                                                <binding destination="331" name="value" keyPath="values.candiNumbers" id="436"/>
+                                            </connections>
+                                        </comboBox>
+                                        <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="304">
+                                            <rect key="frame" x="161" y="248" width="118" height="22"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" state="on" alignment="center" title="Hei 16" drawsBackground="YES" id="391">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                <color key="backgroundColor" red="1" green="0.5" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="460">
+                                            <rect key="frame" x="23" y="326" width="125" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Candidate Charset:" id="461">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <comboBox verticalHuggingPriority="750" fixedFrame="YES" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="462">
+                                            <rect key="frame" x="161" y="319" width="95" height="26"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" title="GB2312" drawsBackground="YES" completes="NO" numberOfVisibleItems="5" id="463">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                <objectValues>
+                                                    <string>GB2312</string>
+                                                    <string>GBK</string>
+                                                    <string>GB18030</string>
+                                                </objectValues>
+                                            </comboBoxCell>
+                                            <connections>
+                                                <binding destination="331" name="value" keyPath="values.charset" id="465"/>
+                                            </connections>
+                                        </comboBox>
+                                        <colorWell fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="466">
+                                            <rect key="frame" x="161" y="174" width="92" height="23"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <color key="color" red="0.058130499000000002" green="0.055541898999999999" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                            <connections>
+                                                <binding destination="331" name="value" keyPath="values.hlColor" id="469">
+                                                    <dictionary key="options">
+                                                        <string key="NSValueTransformerName">NSUnarchiveFromData</string>
+                                                    </dictionary>
+                                                </binding>
+                                            </connections>
+                                        </colorWell>
+                                    </subviews>
+                                </view>
+                            </tabViewItem>
+                            <tabViewItem label="Punctations" identifier="Item 3" id="694">
+                                <view key="view" id="695">
+                                    <rect key="frame" x="10" y="33" width="386" height="357"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="696">
+                                            <rect key="frame" x="17" y="-3" width="352" height="353"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <clipView key="contentView" ambiguous="YES" id="2nh-P1-iZn">
+                                                <rect key="frame" x="1" y="25" width="350" height="327"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                                <subviews>
+                                                    <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" headerView="700" id="699">
+                                                        <rect key="frame" x="0.0" y="0.0" width="350" height="327"/>
+                                                        <autoresizingMask key="autoresizingMask"/>
+                                                        <size key="intercellSpacing" width="3" height="2"/>
+                                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                        <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                                        <tableColumns>
+                                                            <tableColumn identifier="column1" width="55" minWidth="40" maxWidth="1000" id="701">
+                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                                    <font key="font" metaFont="smallSystem"/>
+                                                                    <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
+                                                                </tableHeaderCell>
+                                                                <buttonCell key="dataCell" type="check" bezelStyle="regularSquare" imagePosition="leading" alignment="left" inset="2" id="707">
+                                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                    <font key="font" metaFont="system"/>
+                                                                </buttonCell>
+                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                <connections>
+                                                                    <binding destination="709" name="value" keyPath="arrangedObjects.enabled" id="715"/>
+                                                                </connections>
+                                                            </tableColumn>
+                                                            <tableColumn identifier="column2" editable="NO" width="123" minWidth="40" maxWidth="1000" id="702">
+                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="ASCII Character">
+                                                                    <font key="font" metaFont="smallSystem"/>
+                                                                    <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
+                                                                </tableHeaderCell>
+                                                                <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="703">
+                                                                    <font key="font" metaFont="system"/>
+                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                </textFieldCell>
+                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                <connections>
+                                                                    <binding destination="709" name="value" keyPath="arrangedObjects.ASCII" id="717">
+                                                                        <dictionary key="options">
+                                                                            <integer key="NSConditionallySetsEditable" value="1"/>
+                                                                        </dictionary>
+                                                                    </binding>
+                                                                </connections>
+                                                            </tableColumn>
+                                                            <tableColumn identifier="column3" width="163" minWidth="10" maxWidth="3.4028234663852886e+38" id="705">
+                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Mapped String">
+                                                                    <font key="font" metaFont="smallSystem"/>
+                                                                    <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                                </tableHeaderCell>
+                                                                <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="706">
+                                                                    <font key="font" metaFont="system"/>
+                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                </textFieldCell>
+                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                <connections>
+                                                                    <binding destination="709" name="value" keyPath="arrangedObjects.mappedString" id="719"/>
+                                                                </connections>
+                                                            </tableColumn>
+                                                        </tableColumns>
+                                                    </tableView>
+                                                </subviews>
+                                            </clipView>
+                                            <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="698">
+                                                <rect key="frame" x="-100" y="-100" width="247" height="15"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                            </scroller>
+                                            <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="697">
+                                                <rect key="frame" x="224" y="17" width="15" height="102"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                            </scroller>
+                                            <tableHeaderView key="headerView" id="700">
+                                                <rect key="frame" x="0.0" y="0.0" width="350" height="25"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                            </tableHeaderView>
+                                        </scrollView>
+                                    </subviews>
+                                </view>
+                            </tabViewItem>
+                            <tabViewItem label="About" identifier="Item 4" id="731">
+                                <view key="view" id="732">
+                                    <rect key="frame" x="10" y="33" width="386" height="357"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <button verticalHuggingPriority="750" fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="733">
+                                            <rect key="frame" x="11" y="9" width="166" height="32"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="push" title="Check for Updates..." bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="736">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="checkForUpdates:" target="689" id="737"/>
+                                            </connections>
+                                        </button>
+                                        <button fixedFrame="YES" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="734">
+                                            <rect key="frame" x="177" y="18" width="199" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="Check automatically" bezelStyle="regularSquare" imagePosition="leading" alignment="left" state="on" inset="2" id="735">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <binding destination="331" name="value" keyPath="values.SUEnableAutomaticChecks" id="738"/>
+                                            </connections>
+                                        </button>
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" preferredMaxLayoutWidth="348" translatesAutoresizingMaskIntoConstraints="NO" id="745">
+                                            <rect key="frame" x="17" y="112" width="352" height="233"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" state="on" alignment="center" id="746">
+                                                <font key="font" metaFont="system"/>
+                                                <string key="title">Version 2.0.2.1008
+
+Copyright © 2010 SunPinyin.ORG
+Sun Microsystems, Inc.
+Lei Zhang &lt;phill.zhang@gmail.com&gt;
+Yong Sun &lt;mail@yongsun.me&gt;
+Kefu Chai &lt;tchaikov@gmail.com&gt;
+Wei Xue &lt;breadson.xue@gmail.com&gt;
+Leo Zheng &lt;zym361@gmail.com&gt;
+Mike &lt;mikeandmore@gmail.com&gt;
+chumsdock &lt;vorbei@gmail.com&gt;
+Anthony Lee &lt;don.anthony.lee@gmail.com&gt;</string>
+                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                    </subviews>
+                                </view>
+                            </tabViewItem>
+                        </tabViewItems>
+                    </tabView>
+                </subviews>
+            </view>
+            <point key="canvasLocation" x="140" y="-172"/>
+        </window>
+        <userDefaultsController representsSharedInstance="YES" id="331" userLabel="Shared User Defaults Controller"/>
+        <customObject id="689" customClass="SUUpdater"/>
+        <arrayController id="709">
+            <declaredKeys>
+                <string>enabled</string>
+                <string>ASCII</string>
+                <string>mappedString</string>
+            </declaredKeys>
+            <connections>
+                <binding destination="331" name="contentArray" keyPath="values.punctationMappings" id="720">
+                    <dictionary key="options">
+                        <integer key="NSHandlesContentAsCompoundValue" value="1"/>
+                    </dictionary>
+                </binding>
+            </connections>
+        </arrayController>
+    </objects>
+</document>

--- a/wrapper/macos/Info.plist
+++ b/wrapper/macos/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string>SunPinyin.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.opensolaris.inputmethod.SunPinyin</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/wrapper/macos/SunPinyin.xcodeproj/project.pbxproj
+++ b/wrapper/macos/SunPinyin.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		0752CBF20F9C723600C7096E /* dsa_pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = 0752CBF10F9C723600C7096E /* dsa_pub.pem */; };
 		0752CBF40F9C745200C7096E /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0752CBF30F9C745200C7096E /* Sparkle.framework */; };
-		0752CC1A0F9C77EB00C7096E /* Sparkle.framework in Copy 3rd-party Frameworks */ = {isa = PBXBuildFile; fileRef = 0752CBF30F9C745200C7096E /* Sparkle.framework */; };
+		0752CC1A0F9C77EB00C7096E /* Sparkle.framework in Copy 3rd-party Frameworks */ = {isa = PBXBuildFile; fileRef = 0752CBF30F9C745200C7096E /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		3F32A46D1275172C007FFD4D /* hunpin_seg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F32A46B1275172C007FFD4D /* hunpin_seg.cpp */; };
 		8D11072B0486CEB800E47090 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C165CFE840E0CC02AAC07 /* InfoPlist.strings */; };
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
@@ -20,7 +20,7 @@
 		A44C703E13D9BB010026694E /* imi_plugin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A44C703C13D9BB010026694E /* imi_plugin.cpp */; };
 		A45578F51146A75200592C6E /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = A45578F41146A75200592C6E /* MainMenu.xib */; };
 		A464E2BE0F65211A00148227 /* Growl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A464E2BD0F65211A00148227 /* Growl.framework */; };
-		A464E3740F65261800148227 /* Growl.framework in Copy 3rd-party Frameworks */ = {isa = PBXBuildFile; fileRef = A464E2BD0F65211A00148227 /* Growl.framework */; };
+		A464E3740F65261800148227 /* Growl.framework in Copy 3rd-party Frameworks */ = {isa = PBXBuildFile; fileRef = A464E2BD0F65211A00148227 /* Growl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		A47C487E105E86B5006D528B /* ic_history.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A47C4865105E86B5006D528B /* ic_history.cpp */; };
 		A47C487F105E86B5006D528B /* imi_context.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A47C4867105E86B5006D528B /* imi_context.cpp */; };
 		A47C4880105E86B5006D528B /* imi_data.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A47C4869105E86B5006D528B /* imi_data.cpp */; };
@@ -380,7 +380,7 @@
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0410;
+				LastUpgradeCheck = 1130;
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "SunPinyin" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -516,6 +516,7 @@
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -529,7 +530,7 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "\"$(LOCAL_LIBRARY_DIR)/Input Methods/\"";
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				OTHER_CPLUSPLUSFLAGS = (
 					"-DMACOSX",
 					"-DHAVE_CONFIG_H",
@@ -551,7 +552,7 @@
 		C01FCF4C08A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CODE_SIGN_IDENTITY = "-";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(FRAMEWORK_SEARCH_PATHS_QUOTED_FOR_TARGET_1)",
@@ -563,7 +564,7 @@
 				GCC_MODEL_TUNING = G5;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				OTHER_CPLUSPLUSFLAGS = (
 					"-DMACOSX",
 					"-DHAVE_CONFIG_H",
@@ -584,14 +585,40 @@
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
 					../../cmakebuild,
 					../..,
 					../../src,
 				);
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 			};
 			name = Debug;
@@ -599,9 +626,33 @@
 		C01FCF5008A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/Release";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
 					../../cmakebuild,

--- a/wrapper/macos/SunPinyin.xcodeproj/project.pbxproj
+++ b/wrapper/macos/SunPinyin.xcodeproj/project.pbxproj
@@ -542,6 +542,7 @@
 					"-lsqlite3",
 					"-liconv",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.opensolaris.inputmethod.SunPinyin;
 				PRODUCT_NAME = SunPinyin;
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = app;
@@ -576,6 +577,7 @@
 					"-lsqlite3",
 					"-liconv",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.opensolaris.inputmethod.SunPinyin;
 				PRODUCT_NAME = SunPinyin;
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = app;

--- a/wrapper/macos/SunPinyin.xcodeproj/project.pbxproj
+++ b/wrapper/macos/SunPinyin.xcodeproj/project.pbxproj
@@ -362,7 +362,6 @@
 				8D11072C0486CEB800E47090 /* Sources */,
 				8D11072E0486CEB800E47090 /* Frameworks */,
 				A464E3780F65263000148227 /* Copy 3rd-party Frameworks */,
-				A45578A011469D9300592C6E /* Localize and Compile XIBs */,
 			);
 			buildRules = (
 			);
@@ -419,24 +418,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		A45578A011469D9300592C6E /* Localize and Compile XIBs */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Localize and Compile XIBs";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "ibtool3 --strings-file zh_CN.lproj/MainMenu.strings --write zh_CN.lproj/MainMenu.xib English.lproj/MainMenu.xib\nibtool3 --compile zh_CN.lproj/MainMenu.nib zh_CN.lproj/MainMenu.xib\ncp zh_CN.lproj/MainMenu.nib \"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/zh_CN.lproj/MainMenu.nib\"";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		8D11072C0486CEB800E47090 /* Sources */ = {


### PR DESCRIPTION
Upgrade XIB file to fix build on recent XCode.

Upgrade minimum version to 10.9 due to new XIB user interface layout backward-compatibility.

Force to do codesign on dependencies.
Otherwise, it cannot be launched on macOS 10.14 or higher, even if on debug mode.

Also, I use some XCode-recommended configuration.
For example, the identifier is defined somewhere other than `Info.plist`.