### PR TITLE
Fix riscv build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -345,6 +345,7 @@ def AppendEndianCheck(conf):
   || defined(_M_ALPHA)  || defined(__amd64) \
   || defined(__amd64__) || defined(_M_AMD64) \
   || defined(__x86_64)  || defined(__x86_64__) \
+  || defined(__riscv__) || defined(__riscv) \
   || defined(_M_X64)    || defined(__bfin__) \
   || defined(__alpha__) || defined(__ARMEL__) \
   || defined(_MIPSEL)   || (defined(__sh__) && defined(__LITTLE_ENDIAN__)) \


### PR DESCRIPTION
Define words endian in `SConstruct` for RISC-V architecture.