### PR TITLE
SConstruct: Add support for LoongArch architecture

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -349,7 +349,7 @@ def AppendEndianCheck(conf):
   || defined(_M_X64)    || defined(__bfin__) \
   || defined(__alpha__) || defined(__ARMEL__) \
   || defined(_MIPSEL)   || (defined(__sh__) && defined(__LITTLE_ENDIAN__)) \
-  || defined(__riscv) \
+  || defined(__riscv)   || defined(__loongarch__) \
   || defined(__AARCH64EL__)
 # undef WORDS_BIGENDIAN
 


### PR DESCRIPTION
Hi,There are some errors when compiling on the LoongArch64 architecture, so I submitted this pr to add LoongArch support.

About LoongArch:
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.
Documentations:https://loongson.github.io/LoongArch-Documentation/README-EN.html

thanks!