### PR TITLE
ibus-setup: drop use of broken API to avoid crash error

### DIFF
--- a/wrapper/ibus/setup/main.py
+++ b/wrapper/ibus/setup/main.py
@@ -503,7 +503,10 @@ class MainWindow():
         locale.setlocale(locale.LC_ALL, "")
         localedir = os.getenv("IBUS_LOCALEDIR")
         gettext.bindtextdomain(GETTEXT_PACKAGE, localedir)
-        gettext.bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8")
+        try:
+            gettext.bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8")
+        except AttributeError:
+            pass
 
     def __init_options(self):
         self.__fuzzy_setup = FuzzySetupDialog()


### PR DESCRIPTION
ibus-setup don't work with python 3.11+, catch exception of gettext to aoid it.

$ ibus-setup
Traceback (most recent call last):
  File "/usr/share//ibus-sunpinyin/setup/main.py", line 627, in <module>
    MainWindow().run()
  File "/usr/share//ibus-sunpinyin/setup/main.py", line 487, in run
    self.__init_ui("main_window")
  File "/usr/share//ibus-sunpinyin/setup/main.py", line 492, in __init_ui
    self.__init_gettext()
  File "/usr/share//ibus-sunpinyin/setup/main.py", line 506, in __init_gettext
    gettext.bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8")
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'gettext' has no attribute 'bind_textdomain_codeset'