### PR TITLE
wrapper/ibus/setup: remove gettext.bind_textdomain_codeset() call

### DIFF
--- a/wrapper/ibus/setup/main.py
+++ b/wrapper/ibus/setup/main.py
@@ -503,10 +503,6 @@ class MainWindow():
         locale.setlocale(locale.LC_ALL, "")
         localedir = os.getenv("IBUS_LOCALEDIR")
         gettext.bindtextdomain(GETTEXT_PACKAGE, localedir)
-        try:
-            gettext.bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8")
-        except AttributeError:
-            pass
 
     def __init_options(self):
         self.__fuzzy_setup = FuzzySetupDialog()


### PR DESCRIPTION
gettext.bind_textdomain_codeset() was deprecated in Python 3.8 and then removed in Python 3.10, see
https://docs.python.org/3.9/library/gettext.html#gettext.bind_textdomain_codeset since Python 3.8 was EOL on 7th October 2024. so let's stop calling this API.